### PR TITLE
More bugfixes

### DIFF
--- a/Clicker.xcodeproj/project.pbxproj
+++ b/Clicker.xcodeproj/project.pbxproj
@@ -75,6 +75,8 @@
 		C270524C209D51A600C7980F /* CardController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C270524B209D51A600C7980F /* CardController+Extension.swift */; };
 		C275A1BE2098BE9100815951 /* EditPollViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C275A1BD2098BE9100815951 /* EditPollViewController.swift */; };
 		C27BF1001F93E7C100C51095 /* ClickerQuark.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27BF0FF1F93E7C100C51095 /* ClickerQuark.swift */; };
+		C2833DF62158747C00586D87 /* PollsDateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2833DF52158747B00586D87 /* PollsDateViewController.swift */; };
+		C2833DF82158753800586D87 /* PollsDateViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2833DF72158753800586D87 /* PollsDateViewController+Extension.swift */; };
 		C28679DD2155A5A300554F7B /* PollBuilderMCOptionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C28679DC2155A5A300554F7B /* PollBuilderMCOptionModel.swift */; };
 		C28679DF2155A83000554F7B /* PollBuilderMCOptionSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C28679DE2155A83000554F7B /* PollBuilderMCOptionSectionController.swift */; };
 		C28AD561205CB7D50053AD62 /* QuestionSectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C28AD560205CB7D50053AD62 /* QuestionSectionCell.swift */; };
@@ -202,6 +204,8 @@
 		C270524B209D51A600C7980F /* CardController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardController+Extension.swift"; sourceTree = "<group>"; };
 		C275A1BD2098BE9100815951 /* EditPollViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPollViewController.swift; sourceTree = "<group>"; };
 		C27BF0FF1F93E7C100C51095 /* ClickerQuark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClickerQuark.swift; sourceTree = "<group>"; };
+		C2833DF52158747B00586D87 /* PollsDateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollsDateViewController.swift; sourceTree = "<group>"; };
+		C2833DF72158753800586D87 /* PollsDateViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PollsDateViewController+Extension.swift"; sourceTree = "<group>"; };
 		C28679DC2155A5A300554F7B /* PollBuilderMCOptionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollBuilderMCOptionModel.swift; sourceTree = "<group>"; };
 		C28679DE2155A83000554F7B /* PollBuilderMCOptionSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollBuilderMCOptionSectionController.swift; sourceTree = "<group>"; };
 		C28AD560205CB7D50053AD62 /* QuestionSectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionSectionCell.swift; sourceTree = "<group>"; };
@@ -560,6 +564,8 @@
 			children = (
 				6353FD392086DDC900E16EB2 /* CardController.swift */,
 				C270524B209D51A600C7980F /* CardController+Extension.swift */,
+				C2833DF52158747B00586D87 /* PollsDateViewController.swift */,
+				C2833DF72158753800586D87 /* PollsDateViewController+Extension.swift */,
 				C2504A56209956C600DC5EDC /* DeletePollViewController.swift */,
 				63A4A64A2094F26F00523AE6 /* DraftsViewController.swift */,
 				C203E563213330AC0016A147 /* DraftsViewController+Extension.swift */,
@@ -890,10 +896,12 @@
 				C203E564213330AC0016A147 /* DraftsViewController+Extension.swift in Sources */,
 				D13E9092208712A300856DD4 /* PollBuilderViewController.swift in Sources */,
 				C2113B1F214AD72800BBBB82 /* CurrentStateParser.swift in Sources */,
+				C2833DF62158747C00586D87 /* PollsDateViewController.swift in Sources */,
 				63ACEC79214D61BE00D555F1 /* SettingsLinkCell.swift in Sources */,
 				63A4A6482094D5EF00523AE6 /* FRPollBuilderView.swift in Sources */,
 				C26D5F53214F5FE900548255 /* PollsDateCell.swift in Sources */,
 				C2A0F7CD213A106C00A28D75 /* HamburgerCardModel.swift in Sources */,
+				C2833DF82158753800586D87 /* PollsDateViewController+Extension.swift in Sources */,
 				6389C94E20858D5400F78003 /* PollPreviewCell.swift in Sources */,
 				C2B9180D208CE7320030822F /* FeedbackViewController.swift in Sources */,
 				C7D6AF591F93DE4E003ABA10 /* Constants.swift in Sources */,

--- a/Clicker/AppDelegate.swift
+++ b/Clicker/AppDelegate.swift
@@ -20,7 +20,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, GIDSignInDelegate {
     var window: UIWindow?
     var pollsNavigationController: UINavigationController!
     
-    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         setupWindow()
         setupNavigationController()

--- a/Clicker/Extensions/Utils.swift
+++ b/Clicker/Extensions/Utils.swift
@@ -55,11 +55,10 @@ func buildPollOptionsModel(from poll: Poll, userRole: UserRole) -> PollOptionsMo
     return PollOptionsModel(type: type, pollState: poll.state)
 }
 
-func calculatePollOptionsCellHeight(for pollOptionsModel: PollOptionsModel, state: CardControllerState) -> CGFloat {
+func calculatePollOptionsCellHeight(for pollOptionsModel: PollOptionsModel) -> CGFloat {
     let verticalPadding: CGFloat = LayoutConstants.pollOptionsVerticalPadding * 2
     var optionModels: [OptionModel]
     var optionHeight: CGFloat
-    let isHorizontal = state == .horizontal
     switch pollOptionsModel.type {
     case .mcResult(let mcResultModels):
         optionModels = mcResultModels

--- a/Clicker/Extensions/Utils.swift
+++ b/Clicker/Extensions/Utils.swift
@@ -63,13 +63,13 @@ func calculatePollOptionsCellHeight(for pollOptionsModel: PollOptionsModel, stat
     switch pollOptionsModel.type {
     case .mcResult(let mcResultModels):
         optionModels = mcResultModels
-        optionHeight = isHorizontal ? LayoutConstants.horizontalMCOptionCellHeight : LayoutConstants.verticalMCOptionCellHeight
+        optionHeight = LayoutConstants.mcOptionCellHeight
     case .mcChoice(let mcChoiceModels):
         optionModels = mcChoiceModels
-        optionHeight = isHorizontal ? LayoutConstants.horizontalMCOptionCellHeight : LayoutConstants.verticalMCOptionCellHeight
+        optionHeight = LayoutConstants.mcOptionCellHeight
     case .frOption(let frOptionModels):
         optionModels = frOptionModels
-        optionHeight = isHorizontal ? LayoutConstants.horizontalFROptionCellHeight : LayoutConstants.verticalFROptionCellHeight
+        optionHeight = LayoutConstants.frOptionCellHeight
     }
     let maximumNumberVisibleOptions = 6
     let numOptions = min(optionModels.count, maximumNumberVisibleOptions)

--- a/Clicker/Extensions/Utils.swift
+++ b/Clicker/Extensions/Utils.swift
@@ -15,10 +15,11 @@ func intToMCOption(_ intOption: Int) -> String {
     return String(Character(UnicodeScalar(intOption + Int(("A" as UnicodeScalar).value))!))
 }
 
-// GET MM/DD/YYYY OF TODAY
+// GET M/DD/YYYY OF TODAY
+// Ex) 9/25/18, 10/27/18
 func getTodaysDate() -> String {
     let formatter = DateFormatter()
-    formatter.dateFormat = "MM/dd/yy"
+    formatter.dateFormat = "M/dd/yyyy"
     return formatter.string(from: Date())
 }
 

--- a/Clicker/Models/CurrentState.swift
+++ b/Clicker/Models/CurrentState.swift
@@ -19,28 +19,5 @@ class CurrentState {
         self.results = results
         self.answers = answers
     }
-    
-    // GET TOTAL ANSWERS SUBMITTED
-    func getTotalCount() -> Int {
-        var counter = 0
-        for dict in results.values {
-            if let d = dict as? [String:Any], let val = d["count"] as? Int {
-                counter += val
-            }
-        }
-        return counter
-    }
-    
-    // Returns array representation of results
-    // Ex) [('Blah', 3), ('Jupiter', 2)...]
-    func getFRResultsArray() -> [(String, Int)] {
-        var resultsArr: [(String, Int)] = []
-        results.forEach { (key, val) in
-            if let choiceJSON = val as? [String:Any] {
-                resultsArr.append((key, (choiceJSON["count"] as! Int)))
-            }
-        }
-        return resultsArr
-    }
-    
+
 }

--- a/Clicker/Models/Parsers/PollParser.swift
+++ b/Clicker/Models/Parsers/PollParser.swift
@@ -16,8 +16,13 @@ class PollParser: Parser {
     static func parseItem(json: JSON) -> Poll {
         let id = json[ParserKeys.idKey].intValue
         let text = json[ParserKeys.textKey].stringValue
-        let options = json[ParserKeys.optionsKey].arrayValue.map { $0.stringValue }
         let results = json[ParserKeys.resultsKey].dictionaryValue
+        var options: [String]
+        if let optionsArray = json[ParserKeys.optionsKey].array {
+            options = optionsArray.map { $0.stringValue }
+        } else {
+            options = results.keys.sorted()
+        }
         let questionType: QuestionType = json[ParserKeys.typeKey].stringValue == Identifiers.multipleChoiceIdentifier
             ? .multipleChoice
             : .freeResponse
@@ -32,8 +37,13 @@ class PollParser: Parser {
     static func parseItem(json: JSON, state: PollState) -> Poll {
         let id = json[ParserKeys.idKey].intValue
         let text = json[ParserKeys.textKey].stringValue
-        let options = json[ParserKeys.optionsKey].arrayValue.map { $0.stringValue }
         let results = json[ParserKeys.resultsKey].dictionaryValue
+        var options: [String]
+        if let optionsArray = json[ParserKeys.optionsKey].array {
+            options = optionsArray.map { $0.stringValue }
+        } else {
+            options = results.keys.sorted()
+        }
         let questionType: QuestionType = json[ParserKeys.typeKey].stringValue == Identifiers.multipleChoiceIdentifier
             ? .multipleChoice
             : .freeResponse

--- a/Clicker/Models/Socket.swift
+++ b/Clicker/Models/Socket.swift
@@ -85,4 +85,8 @@ class Socket {
         socket.connect()
     }
 
+    func updateDelegate(_ delegate: SocketDelegate) {
+        self.delegate = delegate
+    }
+    
 }

--- a/Clicker/SectionControllers/FROptionSectionController.swift
+++ b/Clicker/SectionControllers/FROptionSectionController.swift
@@ -10,7 +10,6 @@ import IGListKit
 
 protocol FROptionSectionControllerDelegate {
     
-    var cardControllerState: CardControllerState { get }
     var pollState: PollState { get }
     
     func frOptionSectionControllerDidUpvote(sectionController: FROptionSectionController)

--- a/Clicker/SectionControllers/MCChoiceSectionController.swift
+++ b/Clicker/SectionControllers/MCChoiceSectionController.swift
@@ -9,7 +9,6 @@
 import IGListKit
 
 protocol MCChoiceSectionControllerDelegate {
-    var cardControllerState: CardControllerState { get }
     var pollState: PollState { get }
     
     func mcChoiceSectionControllerWasSelected(sectionController: MCChoiceSectionController)

--- a/Clicker/SectionControllers/MCChoiceSectionController.swift
+++ b/Clicker/SectionControllers/MCChoiceSectionController.swift
@@ -29,9 +29,7 @@ class MCChoiceSectionController: ListSectionController {
         guard let containerSize = collectionContext?.containerSize else {
             return .zero
         }
-        let cellHeight = delegate.cardControllerState == .horizontal
-            ? LayoutConstants.horizontalMCOptionCellHeight
-            : LayoutConstants.verticalMCOptionCellHeight
+        let cellHeight = LayoutConstants.mcOptionCellHeight
         return CGSize(width: containerSize.width, height: cellHeight)
     }
     

--- a/Clicker/SectionControllers/MCResultSectionController.swift
+++ b/Clicker/SectionControllers/MCResultSectionController.swift
@@ -28,9 +28,7 @@ class MCResultSectionController: ListSectionController {
         guard let containerSize = collectionContext?.containerSize else {
             return .zero
         }
-        let cellHeight = delegate.cardControllerState == .horizontal
-            ? LayoutConstants.horizontalMCOptionCellHeight
-            : LayoutConstants.verticalMCOptionCellHeight
+        let cellHeight = LayoutConstants.mcOptionCellHeight
         return CGSize(width: containerSize.width, height: cellHeight)
     }
     

--- a/Clicker/SectionControllers/MCResultSectionController.swift
+++ b/Clicker/SectionControllers/MCResultSectionController.swift
@@ -10,8 +10,8 @@ import IGListKit
 
 protocol MCResultSectionControllerDelegate {
     
-    var cardControllerState: CardControllerState { get }
     var userRole: UserRole { get }
+
 }
 
 class MCResultSectionController: ListSectionController {

--- a/Clicker/SectionControllers/PollOptionsSectionController.swift
+++ b/Clicker/SectionControllers/PollOptionsSectionController.swift
@@ -10,7 +10,6 @@ import IGListKit
 
 protocol PollOptionsSectionControllerDelegate {
     
-    var cardControllerState: CardControllerState { get }
     var userRole: UserRole { get }
     
     func pollOptionsSectionControllerDidSubmitChoice(sectionController: PollOptionsSectionController, choice: String)
@@ -33,7 +32,7 @@ class PollOptionsSectionController: ListSectionController {
         guard let containerSize = collectionContext?.containerSize else {
             return .zero
         }
-        let cellHeight = calculatePollOptionsCellHeight(for: pollOptionsModel, state: delegate.cardControllerState)
+        let cellHeight = calculatePollOptionsCellHeight(for: pollOptionsModel)
         return CGSize(width: containerSize.width, height: cellHeight)
     }
     
@@ -50,10 +49,6 @@ class PollOptionsSectionController: ListSectionController {
 }
 
 extension PollOptionsSectionController: PollOptionsCellDelegate {
-    
-    var cardControllerState: CardControllerState {
-        return delegate.cardControllerState
-    }
     
     var userRole: UserRole {
         return delegate.userRole

--- a/Clicker/SectionControllers/PollSectionController.swift
+++ b/Clicker/SectionControllers/PollSectionController.swift
@@ -11,7 +11,6 @@ import IGListKit
 
 protocol PollSectionControllerDelegate {
     
-    var cardControllerState: CardControllerState { get }
     var role: UserRole { get }
     
     func pollSectionControllerDidSubmitChoiceForPoll(sectionController: PollSectionController, choice: String, poll: Poll)
@@ -53,10 +52,6 @@ class PollSectionController: ListSectionController {
 }
 
 extension PollSectionController: CardCellDelegate {
-    
-    var cardControllerState: CardControllerState {
-        return delegate.cardControllerState
-    }
     
     var userRole: UserRole {
         return delegate.role

--- a/Clicker/SectionControllers/PollsDateSectionController.swift
+++ b/Clicker/SectionControllers/PollsDateSectionController.swift
@@ -10,7 +10,7 @@ import IGListKit
 
 protocol PollsDateSectionControllerDelegate {
     
-    func pollsDateSectionControllerSwitchToHorizontalWith(index: Int)
+    func pollsDateSectionControllerDidTap(for pollsDateModel: PollsDateModel)
     
 }
 
@@ -46,7 +46,7 @@ class PollsDateSectionController: ListSectionController {
     }
     
     override func didSelectItem(at index: Int) {
-        delegate.pollsDateSectionControllerSwitchToHorizontalWith(index: index)
+        delegate.pollsDateSectionControllerDidTap(for: pollsDateModel)
     }
     
 }

--- a/Clicker/SectionControllers/QuestionSectionController.swift
+++ b/Clicker/SectionControllers/QuestionSectionController.swift
@@ -17,7 +17,7 @@ class QuestionSectionController: ListSectionController {
         guard let containerSize = collectionContext?.containerSize else {
             return .zero
         }
-        return CGSize(width: containerSize.width, height: LayoutConstants.verticalQuestionCellHeight)
+        return CGSize(width: containerSize.width, height: LayoutConstants.questionCellHeight)
     }
     
     override func cellForItem(at index: Int) -> UICollectionViewCell {

--- a/Clicker/Supporting/Constants.swift
+++ b/Clicker/Supporting/Constants.swift
@@ -72,11 +72,9 @@ struct Routes {
 }
 
 struct LayoutConstants {
-    static let verticalQuestionCellHeight: CGFloat = 40
-    static let verticalMCOptionCellHeight: CGFloat = 44
-    static let horizontalMCOptionCellHeight: CGFloat = 50
-    static let horizontalFROptionCellHeight: CGFloat = 58
-    static let verticalFROptionCellHeight: CGFloat = 52
+    static let questionCellHeight: CGFloat = 46
+    static let mcOptionCellHeight: CGFloat = 50
+    static let frOptionCellHeight: CGFloat = 58
     static let frInputCellHeight: CGFloat = 64
     static let pollMiscellaneousCellHeight: CGFloat = 30
     static let separatorLineCellHeight: CGFloat = 1

--- a/Clicker/Supporting/Constants.swift
+++ b/Clicker/Supporting/Constants.swift
@@ -58,6 +58,9 @@ struct Identifiers {
 }
 
 struct Routes {
+    static let adminEnded = "admin/poll/ended"
+    static let adminUpdateTally = "admin/poll/updateTally"
+    static let count = "user/count"
     static let serverEnd = "server/poll/end"
     static let serverShare = "server/poll/results"
     static let serverStart = "server/poll/start"
@@ -66,20 +69,17 @@ struct Routes {
     static let userStart = "user/poll/start"
     static let userEnd = "user/poll/end"
     static let userShare = "user/poll/results"
-    static let adminUpdateTally = "admin/poll/updateTally"
-    static let adminEnded = "admin/poll/ended"
-    static let count = "user/count"
 }
 
 struct LayoutConstants {
-    static let questionCellHeight: CGFloat = 46
-    static let mcOptionCellHeight: CGFloat = 50
-    static let frOptionCellHeight: CGFloat = 58
     static let frInputCellHeight: CGFloat = 64
-    static let pollMiscellaneousCellHeight: CGFloat = 30
-    static let separatorLineCellHeight: CGFloat = 1
+    static let frOptionCellHeight: CGFloat = 58
     static let hamburgerCardCellHeight: CGFloat = 25
+    static let mcOptionCellHeight: CGFloat = 50
+    static let pollMiscellaneousCellHeight: CGFloat = 30
     static let pollOptionsVerticalPadding: CGFloat = 10
+    static let questionCellHeight: CGFloat = 46
+    static let separatorLineCellHeight: CGFloat = 1
 }
 
 struct ParserKeys {
@@ -96,20 +96,20 @@ struct ParserKeys {
 }
 
 struct RequestKeys {
+    static let choiceKey = "choice"
+    static let countKey = "count"
     static let googleIdKey = "googleId"
     static let optionsKey = "options"
     static let pollKey = "poll"
-    static let choiceKey = "choice"
-    static let countKey = "count"
+    static let sharedKey = "shared"
     static let textKey = "text"
     static let typeKey = "type"
-    static let sharedKey = "shared"
     static let userTypeKey = "userType"
 }
 
 struct StringConstants {
-    static let multipleChoice = "Multiple Choice"
     static let freeResponse = "Free Response"
+    static let multipleChoice = "Multiple Choice"
 }
 
 enum Keys: String {

--- a/Clicker/ViewControllers/CardController+Extension.swift
+++ b/Clicker/ViewControllers/CardController+Extension.swift
@@ -164,6 +164,7 @@ extension CardController: SocketDelegate {
     func sessionDisconnected() {}
     
     func receivedUserCount(_ count: Int) {
+        numberOfPeople = count
         peopleButton.setTitle("\(count)", for: .normal)
     }
     

--- a/Clicker/ViewControllers/CardController+Extension.swift
+++ b/Clicker/ViewControllers/CardController+Extension.swift
@@ -178,7 +178,7 @@ extension CardController: SocketDelegate {
     }
     
     func pollEnded(_ poll: Poll, userRole: UserRole) {
-        guard let latestPoll = getLatestPoll() else { return }
+        guard let latestPoll = pollsDateModel.polls.last else { return }
         if userRole == .admin {
             latestPoll.id = poll.id
             updateLatestPoll(with: latestPoll)
@@ -189,7 +189,7 @@ extension CardController: SocketDelegate {
             let updatedPoll = Poll(id: latestPoll.id, text: latestPoll.text, questionType: latestPoll.questionType, options: latestPoll.options, results: latestPoll.results, state: .ended, answer: latestPoll.answer)
             updateLatestPoll(with: updatedPoll)
         case .multipleChoice:
-            endPoll(poll: poll)
+            updateLatestPoll(with: poll)
         }
         adapter.performUpdates(animated: false, completion: nil)
     }
@@ -223,10 +223,6 @@ extension CardController: SocketDelegate {
         socket.socket.emit(Routes.serverShare, [])
     }
     
-    func endPoll(poll: Poll) {
-        updateLatestPoll(with: poll)
-    }
-    
     func updatedPollOptions(for poll: Poll, currentState: CurrentState) -> [String] {
         var updatedOptions = poll.options.filter { (option) -> Bool in
             return currentState.results[option] != nil
@@ -237,7 +233,7 @@ extension CardController: SocketDelegate {
     }
     
     func updateWithCurrentState(currentState: CurrentState, pollState: PollState?) {
-        guard let latestPoll = getLatestPoll() else { return }
+        guard let latestPoll = pollsDateModel.polls.last else { return }
         let updatedPollState = pollState ?? latestPoll.state
         // For FR, options is initialized to be an empty array so we need to update it whenever we receive results.
         if latestPoll.questionType == .freeResponse {
@@ -248,24 +244,9 @@ extension CardController: SocketDelegate {
     }
     
     func updateLatestPoll(with poll: Poll) {
-//        guard let latestPollsDateModel = pollsDateArray.last else { return }
-//        let todaysDate = getTodaysDate()
-//        if (latestPollsDateModel.date != todaysDate) {
-//            // User has no polls for today yet
-//            let todayPollsDateModel = PollsDateModel(date: todaysDate, polls: [poll])
-//            pollsDateArray.append(todayPollsDateModel)
-//        } else {
-//            // User has polls for today, so just update latest poll for today
-//            let todayPolls = latestPollsDateModel.polls
-//            poll.answer = pollsDateArray.last?.polls.last?.answer
-//            pollsDateArray[pollsDateArray.count - 1].polls[todayPolls.count - 1] = poll
-//        }
-    }
-    
-    func getLatestPoll() -> Poll? {
-        return nil
-//        guard let latestPollsDateModel = pollsDateArray.last else { return nil }
-//        return latestPollsDateModel.polls.last
+        if pollsDateModel.polls.isEmpty { return }
+        let numPolls = pollsDateModel.polls.count
+        pollsDateModel.polls[numPolls - 1] = poll
     }
     
 }

--- a/Clicker/ViewControllers/CardController+Extension.swift
+++ b/Clicker/ViewControllers/CardController+Extension.swift
@@ -81,12 +81,17 @@ extension CardController: PollBuilderViewControllerDelegate {
         socket.socket.emit(Routes.serverStart, socketQuestion)
         let results = buildEmptyResultsFromOptions(options: options, questionType: type)
         let newPoll = Poll(text: text, questionType: type, options: options, results: results, state: state, answer: nil)
-        appendPoll(poll: newPoll)
-        adapter.performUpdates(animated: false) { completed in
-            if completed {
-                self.scrollToLatestPoll()
+        pollsDateModel.polls.append(newPoll)
+        if pollsDateModel.date == getTodaysDate() {
+            adapter.performUpdates(animated: false) { completed in
+                if completed {
+                    self.scrollToLatestPoll()
+                }
             }
+            return
         }
+        self.navigationController?.popViewController(animated: false)
+        delegate.cardControllerDidStartNewPoll(poll: newPoll)
     }
     
     func showNavigationBar() {
@@ -164,7 +169,7 @@ extension CardController: SocketDelegate {
     
     func pollStarted(_ poll: Poll) {
         if userRole == .admin { return }
-        appendPoll(poll: poll)
+        pollsDateModel.polls.append(poll)
         adapter.performUpdates(animated: false) { completed in
             if completed {
                 self.scrollToLatestPoll()
@@ -216,17 +221,6 @@ extension CardController: SocketDelegate {
     
     func emitShareResults() {
         socket.socket.emit(Routes.serverShare, [])
-    }
-    
-    func appendPoll(poll: Poll) {
-//        if currentIndex == -1 {
-//            let date = getTodaysDate()
-//            let newPollsDate = PollsDateModel(date: date, polls: [poll])
-//            pollsDateArray.append(newPollsDate)
-//            currentIndex = 0
-//            return
-//        }
-//        pollsDateArray.last?.polls.append(poll)
     }
     
     func endPoll(poll: Poll) {

--- a/Clicker/ViewControllers/CardController+Extension.swift
+++ b/Clicker/ViewControllers/CardController+Extension.swift
@@ -13,31 +13,12 @@ import UIKit
 extension CardController: ListAdapterDataSource {
     
     func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
-        switch state {
-        case .horizontal?:
-            if (currentIndex > -1) {
-                return pollsDateArray[currentIndex].polls
-            } else {
-                let type: EmptyStateType = .cardController(userRole: userRole)
-                return [EmptyStateModel(type: type)]
-            }
-        default:
-            return pollsDateArray
-        }
+        return pollsDateModel.polls
     }
     
     func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
-        if object is Poll {
-            let pollSectionController = PollSectionController(delegate: self)
-            return pollSectionController
-        } else if object is PollsDateModel {
-            let pollsDateSectionController = PollsDateSectionController(delegate: self)
-            return pollsDateSectionController
-        } else {
-            let shouldDisplayNameView = userRole == .admin && session.name == session.code
-            let emptyStateController = EmptyStateSectionController(session: session, shouldDisplayNameView: shouldDisplayNameView, nameViewDelegate: self)
-            return emptyStateController
-        }
+        let pollSectionController = PollSectionController(delegate: self)
+        return pollSectionController
     }
     
     func emptyView(for listAdapter: ListAdapter) -> UIView? {
@@ -46,10 +27,6 @@ extension CardController: ListAdapterDataSource {
 }
 
 extension CardController: PollSectionControllerDelegate {
-    
-    var cardControllerState: CardControllerState {
-        return state
-    }
     
     var role: UserRole {
         return userRole
@@ -86,15 +63,6 @@ extension CardController: PollSectionControllerDelegate {
     func pollSectionControllerDidShareResultsForPoll(sectionController: PollSectionController, poll: Poll) {
         emitShareResults()
     }
-}
-
-extension CardController: PollsDateSectionControllerDelegate {
- 
-    func pollsDateSectionControllerSwitchToHorizontalWith(index: Int) {
-        currentIndex = index
-        switchTo(state: .horizontal)
-    }
-    
 }
 
 extension CardController: PollBuilderViewControllerDelegate {
@@ -166,7 +134,6 @@ extension CardController: UIScrollViewDelegate {
     }
 
     func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-        if state == .vertical { return }
         // Stop scrollView sliding:
         targetContentOffset.pointee = scrollView.contentOffset
 
@@ -178,7 +145,7 @@ extension CardController: UIScrollViewDelegate {
     }
 
     func scrollToLatestPoll() {
-        let indexOfLatestSection = pollsDateArray[currentIndex].polls.count - 1
+        let indexOfLatestSection = pollsDateModel.polls.count - 1
         let lastIndexPath = IndexPath(item: 0, section: indexOfLatestSection)
         self.collectionView.scrollToItem(at: lastIndexPath, at: .centeredHorizontally, animated: true)
         updateCountLabelText(with: indexOfLatestSection)
@@ -252,14 +219,14 @@ extension CardController: SocketDelegate {
     }
     
     func appendPoll(poll: Poll) {
-        if currentIndex == -1 {
-            let date = getTodaysDate()
-            let newPollsDate = PollsDateModel(date: date, polls: [poll])
-            pollsDateArray.append(newPollsDate)
-            currentIndex = 0
-            return
-        }
-        pollsDateArray.last?.polls.append(poll)
+//        if currentIndex == -1 {
+//            let date = getTodaysDate()
+//            let newPollsDate = PollsDateModel(date: date, polls: [poll])
+//            pollsDateArray.append(newPollsDate)
+//            currentIndex = 0
+//            return
+//        }
+//        pollsDateArray.last?.polls.append(poll)
     }
     
     func endPoll(poll: Poll) {
@@ -287,23 +254,24 @@ extension CardController: SocketDelegate {
     }
     
     func updateLatestPoll(with poll: Poll) {
-        guard let latestPollsDateModel = pollsDateArray.last else { return }
-        let todaysDate = getTodaysDate()
-        if (latestPollsDateModel.date != todaysDate) {
-            // User has no polls for today yet
-            let todayPollsDateModel = PollsDateModel(date: todaysDate, polls: [poll])
-            pollsDateArray.append(todayPollsDateModel)
-        } else {
-            // User has polls for today, so just update latest poll for today
-            let todayPolls = latestPollsDateModel.polls
-            poll.answer = pollsDateArray.last?.polls.last?.answer
-            pollsDateArray[pollsDateArray.count - 1].polls[todayPolls.count - 1] = poll
-        }
+//        guard let latestPollsDateModel = pollsDateArray.last else { return }
+//        let todaysDate = getTodaysDate()
+//        if (latestPollsDateModel.date != todaysDate) {
+//            // User has no polls for today yet
+//            let todayPollsDateModel = PollsDateModel(date: todaysDate, polls: [poll])
+//            pollsDateArray.append(todayPollsDateModel)
+//        } else {
+//            // User has polls for today, so just update latest poll for today
+//            let todayPolls = latestPollsDateModel.polls
+//            poll.answer = pollsDateArray.last?.polls.last?.answer
+//            pollsDateArray[pollsDateArray.count - 1].polls[todayPolls.count - 1] = poll
+//        }
     }
     
     func getLatestPoll() -> Poll? {
-        guard let latestPollsDateModel = pollsDateArray.last else { return nil }
-        return latestPollsDateModel.polls.last
+        return nil
+//        guard let latestPollsDateModel = pollsDateArray.last else { return nil }
+//        return latestPollsDateModel.polls.last
     }
     
 }

--- a/Clicker/ViewControllers/CardController+Extension.swift
+++ b/Clicker/ViewControllers/CardController+Extension.swift
@@ -246,6 +246,7 @@ extension CardController: SocketDelegate {
     func updateLatestPoll(with poll: Poll) {
         if pollsDateModel.polls.isEmpty { return }
         let numPolls = pollsDateModel.polls.count
+        poll.answer = pollsDateModel.polls.last?.answer
         pollsDateModel.polls[numPolls - 1] = poll
     }
     

--- a/Clicker/ViewControllers/CardController.swift
+++ b/Clicker/ViewControllers/CardController.swift
@@ -12,7 +12,7 @@ import UIKit
 
 protocol CardControllerDelegate {
     
-    func cardControllerWillDisappear(with pollsDateModel: PollsDateModel)
+    func cardControllerWillDisappear(with pollsDateModel: PollsDateModel, numberOfPeople: Int)
     func cardControllerDidStartNewPoll(poll: Poll)
     
 }
@@ -36,6 +36,7 @@ class CardController: UIViewController {
     var pollsDateModel: PollsDateModel!
     var currentIndex: Int!
     var indexOfCellBeforeDragging: Int!
+    var numberOfPeople: Int!
     
     // MARK: - Constants    
     let countLabelWidth: CGFloat = 42.0
@@ -48,13 +49,14 @@ class CardController: UIViewController {
     let adminWaitingText = "You haven't asked any polls yet!\nTry it out below."
     let userWaitingText = "Waiting for the host to post a poll."
     
-    init(delegate: CardControllerDelegate, pollsDateModel: PollsDateModel, session: Session, socket: Socket, userRole: UserRole) {
+    init(delegate: CardControllerDelegate, pollsDateModel: PollsDateModel, session: Session, socket: Socket, userRole: UserRole, numberOfPeople: Int) {
         super.init(nibName: nil, bundle: nil)
         self.delegate = delegate
         self.pollsDateModel = pollsDateModel
         self.session = session
         self.socket = socket
         self.userRole = userRole
+        self.numberOfPeople = numberOfPeople
     }
     
     // MARK: - View lifecycle
@@ -138,7 +140,7 @@ class CardController: UIViewController {
         
         peopleButton = UIButton()
         peopleButton.setImage(#imageLiteral(resourceName: "person"), for: .normal)
-        peopleButton.setTitle("0", for: .normal)
+        peopleButton.setTitle("\(numberOfPeople ?? 0)", for: .normal)
         peopleButton.titleLabel?.font = UIFont._16RegularFont
         peopleButton.sizeToFit()
         let peopleBarButton = UIBarButtonItem(customView: peopleButton)
@@ -190,7 +192,7 @@ class CardController: UIViewController {
     }
     
     @objc func goBack() {
-        delegate.cardControllerWillDisappear(with: pollsDateModel)
+        delegate.cardControllerWillDisappear(with: pollsDateModel, numberOfPeople: numberOfPeople)
         self.navigationController?.popViewController(animated: false)
     }
     

--- a/Clicker/ViewControllers/CardController.swift
+++ b/Clicker/ViewControllers/CardController.swift
@@ -68,9 +68,11 @@ class CardController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        let livePollExists = pollsDateModel.polls.last?.state == .live
-        createPollButton.isUserInteractionEnabled = !livePollExists
-        createPollButton.isHidden = livePollExists
+        if createPollButton != nil {
+            let livePollExists = pollsDateModel.polls.last?.state == .live
+            createPollButton.isUserInteractionEnabled = !livePollExists
+            createPollButton.isHidden = livePollExists
+        }
     }
     
     // MARK: - Layout

--- a/Clicker/ViewControllers/CardController.swift
+++ b/Clicker/ViewControllers/CardController.swift
@@ -10,6 +10,13 @@ import IGListKit
 import Presentr
 import UIKit
 
+protocol CardControllerDelegate {
+    
+    func cardControllerWillDisappear(with pollsDateModel: PollsDateModel)
+    func cardControllerDidStartNewPoll(poll: Poll)
+    
+}
+
 class CardController: UIViewController {
     
     // MARK: - View vars
@@ -22,6 +29,7 @@ class CardController: UIViewController {
     var adapter: ListAdapter!
     
     // MARK: - Data vars
+    var delegate: CardControllerDelegate!
     var userRole: UserRole!
     var socket: Socket!
     var session: Session!
@@ -40,8 +48,9 @@ class CardController: UIViewController {
     let adminWaitingText = "You haven't asked any polls yet!\nTry it out below."
     let userWaitingText = "Waiting for the host to post a poll."
     
-    init(pollsDateModel: PollsDateModel, session: Session, userRole: UserRole) {
+    init(delegate: CardControllerDelegate, pollsDateModel: PollsDateModel, session: Session, userRole: UserRole) {
         super.init(nibName: nil, bundle: nil)
+        self.delegate = delegate
         self.session = session
         self.userRole = userRole
         self.pollsDateModel = pollsDateModel
@@ -172,6 +181,7 @@ class CardController: UIViewController {
     }
     
     @objc func goBack() {
+        delegate.cardControllerWillDisappear(with: pollsDateModel)
         self.navigationController?.popViewController(animated: false)
     }
     

--- a/Clicker/ViewControllers/CardController.swift
+++ b/Clicker/ViewControllers/CardController.swift
@@ -193,7 +193,7 @@ class CardController: UIViewController {
     
     @objc func goBack() {
         delegate.cardControllerWillDisappear(with: pollsDateModel, numberOfPeople: numberOfPeople)
-        self.navigationController?.popViewController(animated: false)
+        self.navigationController?.popViewController(animated: true)
     }
     
     required init?(coder aDecoder: NSCoder) {

--- a/Clicker/ViewControllers/CardController.swift
+++ b/Clicker/ViewControllers/CardController.swift
@@ -48,12 +48,13 @@ class CardController: UIViewController {
     let adminWaitingText = "You haven't asked any polls yet!\nTry it out below."
     let userWaitingText = "Waiting for the host to post a poll."
     
-    init(delegate: CardControllerDelegate, pollsDateModel: PollsDateModel, session: Session, userRole: UserRole) {
+    init(delegate: CardControllerDelegate, pollsDateModel: PollsDateModel, session: Session, socket: Socket, userRole: UserRole) {
         super.init(nibName: nil, bundle: nil)
         self.delegate = delegate
-        self.session = session
-        self.userRole = userRole
         self.pollsDateModel = pollsDateModel
+        self.session = session
+        self.socket = socket
+        self.userRole = userRole
     }
     
     // MARK: - View lifecycle
@@ -63,7 +64,7 @@ class CardController: UIViewController {
         view.backgroundColor = .clickerBlack1
         setupNavBar()
         setupViews()
-        self.socket = Socket(id: "\(session.id)", userRole: userRole, delegate: self)
+        socket.updateDelegate(self)
     }
     
     // MARK: - Layout

--- a/Clicker/ViewControllers/CardController.swift
+++ b/Clicker/ViewControllers/CardController.swift
@@ -67,6 +67,12 @@ class CardController: UIViewController {
         socket.updateDelegate(self)
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        let livePollExists = pollsDateModel.polls.last?.state == .live
+        createPollButton.isUserInteractionEnabled = !livePollExists
+        createPollButton.isHidden = livePollExists
+    }
+    
     // MARK: - Layout
     func setupViews() {
         collectionViewLayout = UICollectionViewFlowLayout()

--- a/Clicker/ViewControllers/CardController.swift
+++ b/Clicker/ViewControllers/CardController.swift
@@ -40,14 +40,7 @@ class CardController: UIViewController {
     
     // MARK: - Constants    
     let countLabelWidth: CGFloat = 42.0
-    let gradientViewHeight: CGFloat = 50.0
-    let horizontalCollectionViewTopPadding: CGFloat = 15
-    let verticalCollectionViewBottomInset: CGFloat = 50
-    let verticalCollectionViewTopPadding: CGFloat = 20
-    let adminNothingToSeeText = "Nothing to see here."
-    let userNothingToSeeText = "Nothing to see yet."
-    let adminWaitingText = "You haven't asked any polls yet!\nTry it out below."
-    let userWaitingText = "Waiting for the host to post a poll."
+    let collectionViewTopPadding: CGFloat = 15
     
     init(delegate: CardControllerDelegate, pollsDateModel: PollsDateModel, session: Session, socket: Socket, userRole: UserRole, numberOfPeople: Int) {
         super.init(nibName: nil, bundle: nil)
@@ -84,8 +77,8 @@ class CardController: UIViewController {
         collectionViewLayout.minimumLineSpacing = 0
         collectionViewLayout.scrollDirection = .horizontal
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewLayout)
-        let collectionViewXInset = view.frame.width * 0.05
-        collectionView.contentInset = UIEdgeInsetsMake(0, collectionViewXInset, 0, collectionViewXInset)
+        let collectionViewHorizontalInset = view.frame.width * 0.05
+        collectionView.contentInset = UIEdgeInsetsMake(0, collectionViewHorizontalInset, 0, collectionViewHorizontalInset)
         collectionView.showsVerticalScrollIndicator = false
         collectionView.showsHorizontalScrollIndicator = false
         collectionView.scrollIndicatorInsets = .zero
@@ -115,7 +108,7 @@ class CardController: UIViewController {
         }
         
         collectionView.snp.makeConstraints { make in
-            make.top.equalTo(countLabel.snp.bottom).offset(horizontalCollectionViewTopPadding)
+            make.top.equalTo(countLabel.snp.bottom).offset(collectionViewTopPadding)
             make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
             make.width.equalToSuperview()
             make.centerX.equalToSuperview()

--- a/Clicker/ViewControllers/DeletePollViewController.swift
+++ b/Clicker/ViewControllers/DeletePollViewController.swift
@@ -27,6 +27,14 @@ class DeletePollViewController: UIViewController {
     var userRole: UserRole!
     
     // MARK: - Constants
+    let deleteLabelWidthScale: CGFloat = 0.9
+    let deleteLabelTopPadding: CGFloat = 26
+    let deleteLabelHeight: CGFloat = 40
+    let cancelButtonLeftPadding: CGFloat = 16
+    let cancelButtonHeight: CGFloat = 48
+    let cancelButtonBottomPadding: CGFloat = 18
+    let deleteButtonRightPadding: CGFloat = 16
+    let buttonCenterYOffset: CGFloat = 9
     let navBarTitle = "Are you sure?"
     let adminDeleteLabelText = "Deleting will permanently close the group for all participants and all poll data will be lost."
     let memberDeleteLabelText = "Leaving will remove you from the group and you will no longer have access to its polls."
@@ -77,22 +85,22 @@ class DeletePollViewController: UIViewController {
     
     func setupConstraints() {
         deleteLabel.snp.makeConstraints { make in
-            make.width.equalToSuperview().multipliedBy(0.92)
-            make.height.equalTo(40)
-            make.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(26)
+            make.width.equalToSuperview().multipliedBy(deleteLabelWidthScale)
+            make.height.equalTo(deleteLabelHeight)
+            make.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(deleteLabelTopPadding)
             make.centerX.equalToSuperview()
         }
         
         cancelButton.snp.makeConstraints { make in
-            make.left.equalToSuperview().offset(16)
-            make.width.equalTo(160)
-            make.height.equalTo(48)
-            make.bottom.equalToSuperview().offset(-18)
+            make.leading.equalToSuperview().offset(cancelButtonLeftPadding)
+            make.trailing.equalTo(view.snp.centerX).offset(buttonCenterYOffset * -1)
+            make.height.equalTo(cancelButtonHeight)
+            make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(cancelButtonBottomPadding)
         }
         
         deleteButton.snp.makeConstraints { make in
-            make.right.equalToSuperview().offset(-16)
-            make.width.equalTo(cancelButton.snp.width)
+            make.trailing.equalToSuperview().inset(deleteButtonRightPadding)
+            make.leading.equalTo(view.snp.centerX).offset(buttonCenterYOffset)
             make.height.equalTo(cancelButton.snp.height)
             make.bottom.equalTo(cancelButton.snp.bottom)
         }

--- a/Clicker/ViewControllers/EditNameViewController.swift
+++ b/Clicker/ViewControllers/EditNameViewController.swift
@@ -17,7 +17,12 @@ class EditNameViewController: UIViewController {
     var saveButton: UIButton!
     
     let edgePadding = 18
-    let textFieldHeight = 50
+    let nameTextFieldHeight = 50
+    let nameTextFieldTopPadding: CGFloat = 26
+    let nameTextFieldWidthScale: CGFloat = 0.9
+    let saveButtonWidthScale: CGFloat = 0.5
+    let saveButtonHeight: CGFloat = 48
+    let saveButtonBottomPadding: CGFloat = 16
     
     init(session: Session) {
         super.init(nibName: nil, bundle: nil)
@@ -44,7 +49,7 @@ class EditNameViewController: UIViewController {
         nameTextField.layer.cornerRadius = 5
         nameTextField.layer.borderWidth = 1
         nameTextField.layer.borderColor = UIColor.clickerGrey5.cgColor
-        nameTextField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: edgePadding, height: textFieldHeight))
+        nameTextField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: edgePadding, height: nameTextFieldHeight))
         nameTextField.leftViewMode = .always
         view.addSubview(nameTextField)
         
@@ -59,19 +64,18 @@ class EditNameViewController: UIViewController {
     }
     
     func setupConstraints() {
-        
         nameTextField.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(26)
-            make.width.equalToSuperview().multipliedBy(0.92)
-            make.height.equalTo(textFieldHeight)
+            make.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(nameTextFieldTopPadding)
+            make.width.equalToSuperview().multipliedBy(nameTextFieldWidthScale)
+            make.height.equalTo(nameTextFieldHeight)
             make.centerX.equalToSuperview()
         }
         
         saveButton.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.width.equalTo(160)
-            make.height.equalTo(48)
-            make.bottom.equalToSuperview().offset(-16)
+            make.width.equalToSuperview().multipliedBy(saveButtonWidthScale)
+            make.height.equalTo(saveButtonHeight)
+            make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(saveButtonBottomPadding)
         }
 
     }

--- a/Clicker/ViewControllers/EditNameViewController.swift
+++ b/Clicker/ViewControllers/EditNameViewController.swift
@@ -19,6 +19,11 @@ class EditNameViewController: UIViewController {
     let edgePadding = 18
     let textFieldHeight = 50
     
+    init(session: Session) {
+        super.init(nibName: nil, bundle: nil)
+        self.session = session
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .clickerWhite
@@ -122,4 +127,8 @@ class EditNameViewController: UIViewController {
         }
     }
     
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
 }

--- a/Clicker/ViewControllers/EditPollViewController.swift
+++ b/Clicker/ViewControllers/EditPollViewController.swift
@@ -9,13 +9,15 @@
 import UIKit
 import SnapKit
 
+protocol EditPollViewControllerDelegate {
+    
+    func editPollViewControllerDidDeleteSession(for userRole: UserRole)
+    
+}
+
 class EditPollViewController: UIViewController {
     
-    var session: Session!
-    var homeViewController: UIViewController!
-    var index: Int!
-    var deleteSessionDelegate: DeleteSessionDelegate!
-    
+    // MARK: - View vars
     var buttonStackView: UIStackView!
     var editView: UIView!
     var editNameImageView: UIImageView!
@@ -23,6 +25,18 @@ class EditPollViewController: UIViewController {
     var deleteView: UIView!
     var deleteImageView: UIImageView!
     var deleteButton: UIButton!
+    
+    // MARK: - Data vars
+    var delegate: EditPollViewControllerDelegate!
+    var session: Session!
+    var userRole: UserRole!
+    
+    init(delegate: EditPollViewControllerDelegate, session: Session, userRole: UserRole) {
+        super.init(nibName: nil, bundle: nil)
+        self.delegate = delegate
+        self.session = session
+        self.userRole = userRole
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -107,17 +121,12 @@ class EditPollViewController: UIViewController {
     // MARK: ACTIONS
     
     @objc func deleteBtnPressed() {
-        let deleteVC = DeletePollViewController()
-//        deleteVC.deleteSessionDelegate = deleteSessionDelegate
-        deleteVC.session = session
-        deleteVC.homeViewController = homeViewController
+        let deleteVC = DeletePollViewController(delegate: self, session: session, userRole: userRole)
         self.navigationController?.pushViewController(deleteVC, animated: true)
     }
     
     @objc func editNameBtnPressed() {
-        let editNameVC = EditNameViewController()
-        editNameVC.session = session
-        editNameVC.homeViewController = homeViewController
+        let editNameVC = EditNameViewController(session: session)
         self.navigationController?.pushViewController(editNameVC, animated: true)
     }
     
@@ -136,6 +145,18 @@ class EditPollViewController: UIViewController {
         exitButton.setImage(#imageLiteral(resourceName: "exit"), for: .normal)
         exitButton.addTarget(self, action: #selector(exitBtnPressed), for: .touchUpInside)
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: exitButton)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+extension EditPollViewController: DeletePollViewControllerDelegate {
+    
+    func deletePollViewControllerDidDeleteSession(for userRole: UserRole) {
+        self.delegate.editPollViewControllerDidDeleteSession(for: userRole)
     }
     
 }

--- a/Clicker/ViewControllers/JoinViewController.swift
+++ b/Clicker/ViewControllers/JoinViewController.swift
@@ -83,7 +83,7 @@ class JoinViewController: UIViewController, UITextFieldDelegate {
                     .done { session in
                         GetSortedPolls(id: session.id).make()
                             .done { pollsDateArray in
-                                let cardVC = CardController(pollsDateArray: pollsDateArray, session: session, userRole: .member)
+                                let cardVC = PollsDateViewController(pollsDateArray: pollsDateArray, session: session, userRole: .member)
                                 self.dismiss(animated: true, completion: {
                                     self.dismissController.navigationController?.pushViewController(cardVC, animated: true)
                                     self.dismissController.navigationController?.setNavigationBarHidden(false, animated: true)

--- a/Clicker/ViewControllers/PollsDateViewController+Extension.swift
+++ b/Clicker/ViewControllers/PollsDateViewController+Extension.swift
@@ -165,7 +165,8 @@ extension PollsDateViewController: SocketDelegate {
     }
     
     func pollStarted(_ poll: Poll) {
-
+        appendPoll(poll: poll)
+        adapter.performUpdates(animated: false, completion: nil)
     }
     
     func pollEnded(_ poll: Poll, userRole: UserRole) {

--- a/Clicker/ViewControllers/PollsDateViewController+Extension.swift
+++ b/Clicker/ViewControllers/PollsDateViewController+Extension.swift
@@ -38,7 +38,9 @@ extension PollsDateViewController: ListAdapterDataSource {
 
 extension PollsDateViewController: CardControllerDelegate {
     
-    func cardControllerWillDisappear(with pollsDateModel: PollsDateModel) {
+    func cardControllerWillDisappear(with pollsDateModel: PollsDateModel, numberOfPeople: Int) {
+        self.numberOfPeople = numberOfPeople
+        peopleButton.setTitle("\(numberOfPeople)", for: .normal)
         if let indexOfPollsDateModel = pollsDateArray.firstIndex(where: { $0.date == pollsDateModel.date }) {
             pollsDateArray[indexOfPollsDateModel] = pollsDateModel
             adapter.performUpdates(animated: false, completion: nil)
@@ -48,7 +50,7 @@ extension PollsDateViewController: CardControllerDelegate {
     func cardControllerDidStartNewPoll(poll: Poll) {
         let newPollsDateModel = PollsDateModel(date: getTodaysDate(), polls: [poll])
         pollsDateArray.append(newPollsDateModel)
-        let cardController = CardController(delegate: self, pollsDateModel: newPollsDateModel, session: session, socket: socket, userRole: userRole)
+        let cardController = CardController(delegate: self, pollsDateModel: newPollsDateModel, session: session, socket: socket, userRole: userRole, numberOfPeople: numberOfPeople)
         self.navigationController?.pushViewController(cardController, animated: false)
     }
     
@@ -96,7 +98,7 @@ extension PollsDateViewController: PollSectionControllerDelegate {
 extension PollsDateViewController: PollsDateSectionControllerDelegate {
     
     func pollsDateSectionControllerDidTap(for pollsDateModel: PollsDateModel) {
-        let cardController = CardController(delegate: self, pollsDateModel: pollsDateModel, session: session, socket: socket, userRole: userRole)
+        let cardController = CardController(delegate: self, pollsDateModel: pollsDateModel, session: session, socket: socket, userRole: userRole, numberOfPeople: numberOfPeople)
         self.navigationController?.pushViewController(cardController, animated: false)
     }
     
@@ -121,7 +123,7 @@ extension PollsDateViewController: PollBuilderViewControllerDelegate {
         appendPoll(poll: newPoll)
         adapter.performUpdates(animated: false, completion: nil)
         if let lastPollsDateModel = pollsDateArray.last {
-            let cardController = CardController(delegate: self, pollsDateModel: lastPollsDateModel, session: session, socket: socket, userRole: userRole)
+            let cardController = CardController(delegate: self, pollsDateModel: lastPollsDateModel, session: session, socket: socket, userRole: userRole, numberOfPeople: numberOfPeople)
             self.navigationController?.pushViewController(cardController, animated: false)
         }
     }
@@ -161,6 +163,7 @@ extension PollsDateViewController: SocketDelegate {
     func sessionDisconnected() {}
     
     func receivedUserCount(_ count: Int) {
+        numberOfPeople = count
         peopleButton.setTitle("\(count)", for: .normal)
     }
     

--- a/Clicker/ViewControllers/PollsDateViewController+Extension.swift
+++ b/Clicker/ViewControllers/PollsDateViewController+Extension.swift
@@ -48,7 +48,7 @@ extension PollsDateViewController: CardControllerDelegate {
     func cardControllerDidStartNewPoll(poll: Poll) {
         let newPollsDateModel = PollsDateModel(date: getTodaysDate(), polls: [poll])
         pollsDateArray.append(newPollsDateModel)
-        let cardController = CardController(delegate: self, pollsDateModel: newPollsDateModel, session: session, userRole: userRole)
+        let cardController = CardController(delegate: self, pollsDateModel: newPollsDateModel, session: session, socket: socket, userRole: userRole)
         self.navigationController?.pushViewController(cardController, animated: false)
     }
     
@@ -96,7 +96,7 @@ extension PollsDateViewController: PollSectionControllerDelegate {
 extension PollsDateViewController: PollsDateSectionControllerDelegate {
     
     func pollsDateSectionControllerDidTap(for pollsDateModel: PollsDateModel) {
-        let cardController = CardController(delegate: self, pollsDateModel: pollsDateModel, session: session, userRole: userRole)
+        let cardController = CardController(delegate: self, pollsDateModel: pollsDateModel, session: session, socket: socket, userRole: userRole)
         self.navigationController?.pushViewController(cardController, animated: false)
     }
     
@@ -121,7 +121,7 @@ extension PollsDateViewController: PollBuilderViewControllerDelegate {
         appendPoll(poll: newPoll)
         adapter.performUpdates(animated: false, completion: nil)
         if let lastPollsDateModel = pollsDateArray.last {
-            let cardController = CardController(delegate: self, pollsDateModel: lastPollsDateModel, session: session, userRole: userRole)
+            let cardController = CardController(delegate: self, pollsDateModel: lastPollsDateModel, session: session, socket: socket, userRole: userRole)
             self.navigationController?.pushViewController(cardController, animated: false)
         }
     }

--- a/Clicker/ViewControllers/PollsDateViewController+Extension.swift
+++ b/Clicker/ViewControllers/PollsDateViewController+Extension.swift
@@ -203,7 +203,10 @@ extension PollsDateViewController: SocketDelegate {
         let todaysDate = getTodaysDate()
         if let lastPollDateModel = pollsDateArray.last {
             if lastPollDateModel.date == todaysDate {
-                pollsDateArray.last?.polls.append(poll)
+                var updatedPolls = lastPollDateModel.polls
+                updatedPolls.append(poll)
+                let updatedPollsDateModel = PollsDateModel(date: lastPollDateModel.date, polls: updatedPolls)
+                pollsDateArray[pollsDateArray.count - 1] = updatedPollsDateModel
                 return
             }
         }

--- a/Clicker/ViewControllers/PollsDateViewController+Extension.swift
+++ b/Clicker/ViewControllers/PollsDateViewController+Extension.swift
@@ -52,55 +52,16 @@ extension PollsDateViewController: CardControllerDelegate {
         let newPollsDateModel = PollsDateModel(date: getTodaysDate(), polls: [poll])
         pollsDateArray.append(newPollsDateModel)
         let cardController = CardController(delegate: self, pollsDateModel: newPollsDateModel, session: session, socket: socket, userRole: userRole, numberOfPeople: numberOfPeople)
-        self.navigationController?.pushViewController(cardController, animated: false)
+        self.navigationController?.pushViewController(cardController, animated: true)
     }
     
-}
-
-extension PollsDateViewController: PollSectionControllerDelegate {
-    
-    var role: UserRole {
-        return userRole
-    }
-    
-    func pollSectionControllerDidSubmitChoiceForPoll(sectionController: PollSectionController, choice: String, poll: Poll) {
-        poll.answer = choice
-        var choiceForAnswer: String
-        // choiceForAnswer should be "A" or "B" for multiple choice and the actual response for free response
-        switch poll.questionType {
-        case .multipleChoice:
-            guard let indexOfChoice = poll.options.index(of: choice) else { return }
-            choiceForAnswer = intToMCOption(indexOfChoice)
-        case .freeResponse:
-            choiceForAnswer = choice
-        }
-        let answer = Answer(text: choice, choice: choiceForAnswer, pollId: poll.id)
-        emitAnswer(answer: answer, message: Routes.serverTally)
-    }
-    
-    func pollSectionControllerDidUpvoteChoiceForPoll(sectionController: PollSectionController, choice: String, poll: Poll) {
-        // You can only upvote for FR questions
-        if poll.questionType == .multipleChoice { return }
-        let answer = Answer(text: choice, choice: choice, pollId: poll.id)
-        emitAnswer(answer: answer, message: Routes.serverUpvote)
-    }
-    
-    func pollSectionControllerDidEndPoll(sectionController: PollSectionController, poll: Poll) {
-        createPollButton.isUserInteractionEnabled = true
-        createPollButton.isHidden = false
-        emitEndPoll()
-    }
-    
-    func pollSectionControllerDidShareResultsForPoll(sectionController: PollSectionController, poll: Poll) {
-        emitShareResults()
-    }
 }
 
 extension PollsDateViewController: PollsDateSectionControllerDelegate {
     
     func pollsDateSectionControllerDidTap(for pollsDateModel: PollsDateModel) {
         let cardController = CardController(delegate: self, pollsDateModel: pollsDateModel, session: session, socket: socket, userRole: userRole, numberOfPeople: numberOfPeople)
-        self.navigationController?.pushViewController(cardController, animated: false)
+        self.navigationController?.pushViewController(cardController, animated: true)
     }
     
 }
@@ -125,7 +86,7 @@ extension PollsDateViewController: PollBuilderViewControllerDelegate {
         adapter.performUpdates(animated: false, completion: nil)
         if let lastPollsDateModel = pollsDateArray.last {
             let cardController = CardController(delegate: self, pollsDateModel: lastPollsDateModel, session: session, socket: socket, userRole: userRole, numberOfPeople: numberOfPeople)
-            self.navigationController?.pushViewController(cardController, animated: false)
+            self.navigationController?.pushViewController(cardController, animated: true)
         }
     }
     

--- a/Clicker/ViewControllers/PollsDateViewController+Extension.swift
+++ b/Clicker/ViewControllers/PollsDateViewController+Extension.swift
@@ -1,0 +1,190 @@
+//
+//  PollsDateViewController+Extension.swift
+//  Clicker
+//
+//  Created by Kevin Chan on 9/23/18.
+//  Copyright © 2018 CornellAppDev. All rights reserved.
+//
+
+import IGListKit
+import SwiftyJSON
+import UIKit
+
+extension PollsDateViewController: ListAdapterDataSource {
+    
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
+        if pollsDateArray.isEmpty {
+            let type: EmptyStateType = .cardController(userRole: userRole)
+            return [EmptyStateModel(type: type)]
+        }
+        return pollsDateArray
+    }
+    
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
+        if object is PollsDateModel {
+            let pollsDateSectionController = PollsDateSectionController(delegate: self)
+            return pollsDateSectionController
+        } else {
+            let shouldDisplayNameView = userRole == .admin && session.name == session.code
+            let emptyStateController = EmptyStateSectionController(session: session, shouldDisplayNameView: shouldDisplayNameView, nameViewDelegate: self)
+            return emptyStateController
+        }
+    }
+    
+    func emptyView(for listAdapter: ListAdapter) -> UIView? {
+        return nil
+    }
+}
+
+extension PollsDateViewController: PollSectionControllerDelegate {
+    
+    var role: UserRole {
+        return userRole
+    }
+    
+    func pollSectionControllerDidSubmitChoiceForPoll(sectionController: PollSectionController, choice: String, poll: Poll) {
+        poll.answer = choice
+        var choiceForAnswer: String
+        // choiceForAnswer should be "A" or "B" for multiple choice and the actual response for free response
+        switch poll.questionType {
+        case .multipleChoice:
+            guard let indexOfChoice = poll.options.index(of: choice) else { return }
+            choiceForAnswer = intToMCOption(indexOfChoice)
+        case .freeResponse:
+            choiceForAnswer = choice
+        }
+        let answer = Answer(text: choice, choice: choiceForAnswer, pollId: poll.id)
+        emitAnswer(answer: answer, message: Routes.serverTally)
+    }
+    
+    func pollSectionControllerDidUpvoteChoiceForPoll(sectionController: PollSectionController, choice: String, poll: Poll) {
+        // You can only upvote for FR questions
+        if poll.questionType == .multipleChoice { return }
+        let answer = Answer(text: choice, choice: choice, pollId: poll.id)
+        emitAnswer(answer: answer, message: Routes.serverUpvote)
+    }
+    
+    func pollSectionControllerDidEndPoll(sectionController: PollSectionController, poll: Poll) {
+        createPollButton.isUserInteractionEnabled = true
+        createPollButton.isHidden = false
+        emitEndPoll()
+    }
+    
+    func pollSectionControllerDidShareResultsForPoll(sectionController: PollSectionController, poll: Poll) {
+        emitShareResults()
+    }
+}
+
+extension PollsDateViewController: PollsDateSectionControllerDelegate {
+    
+    func pollsDateSectionControllerDidTap(for pollsDateModel: PollsDateModel) {
+        let cardContorller = CardController(pollsDateModel: pollsDateModel, session: session, userRole: userRole)
+        self.navigationController?.pushViewController(cardContorller, animated: false)
+    }
+    
+}
+
+extension PollsDateViewController: PollBuilderViewControllerDelegate {
+    
+    func startPoll(text: String, type: QuestionType, options: [String], state: PollState) {
+
+    }
+    
+    func showNavigationBar() {
+        navigationController?.setNavigationBarHidden(false, animated: true)
+    }
+    
+    // MARK: - Helpers
+    private func buildEmptyResultsFromOptions(options: [String], questionType: QuestionType) -> [String:JSON] {
+        var results: [String:JSON] = [:]
+        options.enumerated().forEach { (index, option) in
+            let infoDict: JSON = [
+                RequestKeys.textKey: option,
+                RequestKeys.countKey: 0
+            ]
+            let letterChoice = intToMCOption(index) // i.e. A, B, C, ...
+            let key = questionType == .multipleChoice ? letterChoice : option
+            results[key] = infoDict
+        }
+        return results
+    }
+}
+
+extension PollsDateViewController: NameViewDelegate {
+    
+    func nameViewDidUpdateSessionName() {
+        navigationTitleView.updateNameAndCode(name: session.name, code: session.code)
+    }
+    
+}
+
+extension PollsDateViewController: SocketDelegate {
+    
+    func sessionConnected() {}
+    
+    func sessionDisconnected() {}
+    
+    func receivedUserCount(_ count: Int) {
+        peopleButton.setTitle("\(count)", for: .normal)
+    }
+    
+    func pollStarted(_ poll: Poll) {
+
+    }
+    
+    func pollEnded(_ poll: Poll, userRole: UserRole) {
+
+    }
+    
+    func receivedResults(_ currentState: CurrentState) {
+
+    }
+    
+    func updatedTally(_ currentState: CurrentState) {
+    }
+    
+    // MARK: Helpers
+    func emitAnswer(answer: Answer, message: String) {
+        let data: [String:Any] = [
+            RequestKeys.googleIdKey: User.currentUser?.id,
+            RequestKeys.pollKey: answer.pollId,
+            RequestKeys.choiceKey: answer.choice,
+            RequestKeys.textKey: answer.text
+        ]
+        socket.socket.emit(message, data)
+    }
+    
+    func emitEndPoll() {
+        socket.socket.emit(Routes.serverEnd, [])
+    }
+    
+    func emitShareResults() {
+        socket.socket.emit(Routes.serverShare, [])
+    }
+    
+    func appendPoll(poll: Poll) {
+        
+    }
+    
+    func endPoll(poll: Poll) {
+        updateLatestPoll(with: poll)
+    }
+    
+    func updatedPollOptions(for poll: Poll, currentState: CurrentState) -> [String] {
+        return []
+    }
+    
+    func updateWithCurrentState(currentState: CurrentState, pollState: PollState?) {
+       
+    }
+    
+    func updateLatestPoll(with poll: Poll) {
+        
+    }
+    
+    func getLatestPoll() -> Poll? {
+        guard let latestPollsDateModel = pollsDateArray.last else { return nil }
+        return latestPollsDateModel.polls.last
+    }
+    
+}

--- a/Clicker/ViewControllers/PollsDateViewController.swift
+++ b/Clicker/ViewControllers/PollsDateViewController.swift
@@ -109,7 +109,7 @@ class PollsDateViewController: UIViewController {
         
         peopleButton = UIButton()
         peopleButton.setImage(#imageLiteral(resourceName: "person"), for: .normal)
-        peopleButton.setTitle("0", for: .normal)
+        peopleButton.setTitle("\(numberOfPeople ?? 0)", for: .normal)
         peopleButton.titleLabel?.font = UIFont._16RegularFont
         peopleButton.sizeToFit()
         let peopleBarButton = UIBarButtonItem(customView: peopleButton)

--- a/Clicker/ViewControllers/PollsDateViewController.swift
+++ b/Clicker/ViewControllers/PollsDateViewController.swift
@@ -25,6 +25,7 @@ class PollsDateViewController: UIViewController {
     var socket: Socket!
     var session: Session!
     var pollsDateArray: [PollsDateModel]!
+    var numberOfPeople: Int = 0
     
     // MARK: - Constants
     let countLabelWidth: CGFloat = 42.0

--- a/Clicker/ViewControllers/PollsDateViewController.swift
+++ b/Clicker/ViewControllers/PollsDateViewController.swift
@@ -55,9 +55,11 @@ class PollsDateViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        let livePollExists = pollsDateArray.last?.polls.last?.state == .live
-        createPollButton.isUserInteractionEnabled = !livePollExists
-        createPollButton.isHidden = livePollExists
+        if createPollButton != nil {
+            let livePollExists = pollsDateArray.last?.polls.last?.state == .live
+            createPollButton.isUserInteractionEnabled = !livePollExists
+            createPollButton.isHidden = livePollExists
+        }
     }
     
     // MARK: - Layout

--- a/Clicker/ViewControllers/PollsDateViewController.swift
+++ b/Clicker/ViewControllers/PollsDateViewController.swift
@@ -54,6 +54,12 @@ class PollsDateViewController: UIViewController {
         self.socket = Socket(id: "\(session.id)", userRole: userRole, delegate: self)
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        let livePollExists = pollsDateArray.last?.polls.last?.state == .live
+        createPollButton.isUserInteractionEnabled = !livePollExists
+        createPollButton.isHidden = livePollExists
+    }
+    
     // MARK: - Layout
     func setupViews() {
         collectionViewLayout = UICollectionViewFlowLayout()

--- a/Clicker/ViewControllers/PollsDateViewController.swift
+++ b/Clicker/ViewControllers/PollsDateViewController.swift
@@ -29,14 +29,7 @@ class PollsDateViewController: UIViewController {
     
     // MARK: - Constants
     let countLabelWidth: CGFloat = 42.0
-    let gradientViewHeight: CGFloat = 50.0
-    let horizontalCollectionViewTopPadding: CGFloat = 15
-    let verticalCollectionViewBottomInset: CGFloat = 50
-    let verticalCollectionViewTopPadding: CGFloat = 20
-    let adminNothingToSeeText = "Nothing to see here."
-    let userNothingToSeeText = "Nothing to see yet."
-    let adminWaitingText = "You haven't asked any polls yet!\nTry it out below."
-    let userWaitingText = "Waiting for the host to post a poll."
+    let collectionViewTopPadding: CGFloat = 20
     
     init(pollsDateArray: [PollsDateModel], session: Session, userRole: UserRole) {
         super.init(nibName: nil, bundle: nil)
@@ -84,7 +77,7 @@ class PollsDateViewController: UIViewController {
         adapter.dataSource = self
         
         collectionView.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(verticalCollectionViewTopPadding)
+            make.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(collectionViewTopPadding)
             make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
             make.width.equalToSuperview()
             make.centerX.equalToSuperview()
@@ -145,17 +138,19 @@ class PollsDateViewController: UIViewController {
     
     @objc func goBack() {
         socket.socket.disconnect()
-        self.navigationController?.setNavigationBarHidden(true, animated: false)
         if pollsDateArray.isEmpty && session.name == session.code {
             DeleteSession(id: session.id).make()
                 .done {
+                    self.navigationController?.setNavigationBarHidden(true, animated: false)
                     self.navigationController?.popViewController(animated: true)
                     return
                 }.catch { (error) in
                     print(error)
+                    self.navigationController?.setNavigationBarHidden(true, animated: false)
                     self.navigationController?.popViewController(animated: true)
             }
         } else {
+            self.navigationController?.setNavigationBarHidden(true, animated: false)
             self.navigationController?.popViewController(animated: true)
         }
     }

--- a/Clicker/ViewControllers/PollsViewController+Extension.swift
+++ b/Clicker/ViewControllers/PollsViewController+Extension.swift
@@ -64,8 +64,9 @@ extension PollsViewController: PollsCellDelegate {
     
     func pollsCellShouldEditSession(session: Session, userRole: UserRole) {
         let width = ModalSize.full
-        let height = ModalSize.custom(size: editModalHeight)
-        let originY = view.frame.height - CGFloat(editModalHeight)
+        let modalHeight = editModalHeight + view.safeAreaInsets.bottom
+        let height = ModalSize.custom(size: Float(modalHeight))
+        let originY = view.frame.height - modalHeight
         let center = ModalCenterPosition.customOrigin(origin: CGPoint(x: 0, y: originY))
         let customType = PresentationType.custom(width: width, height: height, center: center)
         let presenter = Presentr(presentationType: customType)

--- a/Clicker/ViewControllers/PollsViewController+Extension.swift
+++ b/Clicker/ViewControllers/PollsViewController+Extension.swift
@@ -54,7 +54,7 @@ extension PollsViewController: PollsCellDelegate {
     func pollsCellShouldOpenSession(session: Session, userRole: UserRole) {
         GetSortedPolls(id: session.id).make()
             .done { pollsDateArray in
-                let cardController = CardController(pollsDateArray: pollsDateArray, session: session, userRole: userRole)
+                let cardController = PollsDateViewController(pollsDateArray: pollsDateArray, session: session, userRole: userRole)
                 self.navigationController?.pushViewController(cardController, animated: true)
                 self.navigationController?.setNavigationBarHidden(false, animated: true)
             } .catch { error in

--- a/Clicker/ViewControllers/PollsViewController+Extension.swift
+++ b/Clicker/ViewControllers/PollsViewController+Extension.swift
@@ -62,7 +62,7 @@ extension PollsViewController: PollsCellDelegate {
         }
     }
     
-    func pollsCellShouldEditSession(session: Session) {
+    func pollsCellShouldEditSession(session: Session, userRole: UserRole) {
         let width = ModalSize.full
         let height = ModalSize.custom(size: editModalHeight)
         let originY = view.frame.height - CGFloat(editModalHeight)
@@ -72,11 +72,23 @@ extension PollsViewController: PollsCellDelegate {
         presenter.backgroundOpacity = 0.6
         presenter.dismissOnSwipe = true
         presenter.dismissOnSwipeDirection = .bottom
-        let editPollVC = EditPollViewController()
-        editPollVC.session = session
-        editPollVC.homeViewController = self
+        let editPollVC = EditPollViewController(delegate: self, session: session, userRole: userRole)
         let navigationVC = UINavigationController(rootViewController: editPollVC)
         customPresentViewController(presenter, viewController: navigationVC, animated: true, completion: nil)
+    }
+    
+}
+
+extension PollsViewController: EditPollViewControllerDelegate {
+    
+    func editPollViewControllerDidDeleteSession(for userRole: UserRole) {
+        switch userRole {
+        case .admin:
+            pollTypeModels[0] = PollTypeModel(pollType: .created)
+        case .member:
+            pollTypeModels[1] = PollTypeModel(pollType: .joined)
+        }
+        adapter.performUpdates(animated: false, completion: nil)
     }
     
 }

--- a/Clicker/ViewControllers/PollsViewController.swift
+++ b/Clicker/ViewControllers/PollsViewController.swift
@@ -32,7 +32,7 @@ class PollsViewController: UIViewController {
     
     // MARK: - Constants
     let popupViewHeight: CGFloat = 140
-    let editModalHeight: Float = 205
+    let editModalHeight: CGFloat = 205
     let joinSessionContainerViewHeight: CGFloat = 64
     let codeTextFieldEdgePadding: CGFloat = 18
     let codeTextFieldHeight: CGFloat = 40
@@ -219,6 +219,7 @@ class PollsViewController: UIViewController {
             .done { session in
                 GetSortedPolls(id: session.id).make()
                     .done { pollsDateArray in
+                        self.codeTextField.text = ""
                         let cardVC = CardController(pollsDateArray: pollsDateArray, session: session, userRole: .member)
                         self.navigationController?.pushViewController(cardVC, animated: true)
                         self.navigationController?.setNavigationBarHidden(false, animated: true)

--- a/Clicker/ViewControllers/PollsViewController.swift
+++ b/Clicker/ViewControllers/PollsViewController.swift
@@ -205,7 +205,7 @@ class PollsViewController: UIViewController {
             .done { code in
                 StartSession(code: code, name: code, isGroup: false).make()
                     .done { session in
-                        let cardVC = CardController(pollsDateArray: [], session: session, userRole: .admin)
+                        let cardVC = PollsDateViewController(pollsDateArray: [], session: session, userRole: .admin)
                         self.navigationController?.pushViewController(cardVC, animated: true)
                         self.navigationController?.setNavigationBarHidden(false, animated: true)
                     }.catch { error in
@@ -223,7 +223,7 @@ class PollsViewController: UIViewController {
                 GetSortedPolls(id: session.id).make()
                     .done { pollsDateArray in
                         self.codeTextField.text = ""
-                        let cardVC = CardController(pollsDateArray: pollsDateArray, session: session, userRole: .member)
+                        let cardVC = PollsDateViewController(pollsDateArray: pollsDateArray, session: session, userRole: .member)
                         self.navigationController?.pushViewController(cardVC, animated: true)
                         self.navigationController?.setNavigationBarHidden(false, animated: true)
                     }.catch { error in

--- a/Clicker/ViewControllers/PollsViewController.swift
+++ b/Clicker/ViewControllers/PollsViewController.swift
@@ -37,6 +37,9 @@ class PollsViewController: UIViewController {
     let codeTextFieldEdgePadding: CGFloat = 18
     let codeTextFieldHeight: CGFloat = 40
     let codeTextFieldHorizontalPadding: CGFloat = 12
+    let titleLabelText = "Groups"
+    let createdPollsOptionsText = "Created"
+    let joinedPollsOptionsText = "Joined"
     let codeTextFieldPlaceHolder = "Enter a code..."
     let joinSessionButtonTitle = "Join"
     
@@ -62,12 +65,12 @@ class PollsViewController: UIViewController {
         view.addGestureRecognizer(tapGestureRecognizer)
 
         titleLabel = UILabel()
-        titleLabel.text = "Polls"
+        titleLabel.text = titleLabelText
         titleLabel.font = ._30SemiboldFont
         titleLabel.textColor = .clickerBlack1
         view.addSubview(titleLabel)
         
-        pollsOptionsView = OptionsView(frame: .zero, options: ["Created", "Joined"], sliderBarDelegate: self)
+        pollsOptionsView = OptionsView(frame: .zero, options: [createdPollsOptionsText, joinedPollsOptionsText], sliderBarDelegate: self)
         pollsOptionsView.setBackgroundColor(color: .clickerGrey8)
         view.addSubview(pollsOptionsView)
         

--- a/Clicker/Views/Cards/CardCell.swift
+++ b/Clicker/Views/Cards/CardCell.swift
@@ -13,7 +13,6 @@ import UIKit
 
 protocol CardCellDelegate {
     
-    var cardControllerState: CardControllerState { get }
     var userRole: UserRole { get }
     
     func cardCellDidSubmitChoice(cardCell: CardCell, choice: String)
@@ -41,15 +40,12 @@ class CardCell: UICollectionViewCell {
     var pollOptionsModel: PollOptionsModel!
     var miscellaneousModel: PollMiscellaneousModel!
     var bottomHamburgerCardModel: HamburgerCardModel!
-    var shadowViewWidth: CGFloat!
     var collectionViewRightPadding: CGFloat!
     var timer: Timer!
     var elapsedSeconds: Int = 0
     
     // MARK: - Constants
-    let collectionViewLeftPadding: CGFloat = 5.0
-    let shadowViewCornerRadius: CGFloat = 11.0
-    let shadowHeightScaleFactor: CGFloat = 0.9
+    let collectionViewHorizontalPadding: CGFloat = 5.0
     let questionButtonFontSize: CGFloat = 16.0
     let questionButtonCornerRadius: CGFloat = 23.0
     let questionButtonBorderWidth: CGFloat = 1.0
@@ -88,12 +84,6 @@ class CardCell: UICollectionViewCell {
         adapter.collectionView = collectionView
         adapter.dataSource = self
         
-        shadowView = UIView()
-        shadowView.backgroundColor = .clickerGrey3
-        shadowView.layer.cornerRadius = shadowViewCornerRadius
-        shadowView.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
-        contentView.addSubview(shadowView)
-        
         questionButton = UIButton()
         questionButton.titleLabel?.font = UIFont.systemFont(ofSize: questionButtonFontSize, weight: .semibold)
         questionButton.setTitleColor(.white, for: .normal)
@@ -114,15 +104,8 @@ class CardCell: UICollectionViewCell {
     override func updateConstraints() {
         collectionView.snp.makeConstraints { make in
             make.top.bottom.equalToSuperview()
-            make.leading.equalToSuperview().offset(collectionViewLeftPadding)
-            make.trailing.equalToSuperview().inset(collectionViewRightPadding)
-        }
-        
-        shadowView.snp.updateConstraints { make in
-            make.leading.equalTo(collectionView.snp.trailing)
-            make.width.equalTo(shadowViewWidth)
-            make.centerY.equalToSuperview()
-            make.height.equalToSuperview().multipliedBy(shadowHeightScaleFactor)
+            make.leading.equalToSuperview().offset(collectionViewHorizontalPadding)
+            make.trailing.equalToSuperview().inset(collectionViewHorizontalPadding)
         }
         
         timerLabel.snp.makeConstraints { make in
@@ -143,13 +126,9 @@ class CardCell: UICollectionViewCell {
     func configure(with delegate: CardCellDelegate, poll: Poll, userRole: UserRole) {
         self.delegate = delegate
         self.poll = poll
-        let isVertical = delegate.cardControllerState == .vertical
         let isMember = userRole == .member
-        shadowViewWidth = isVertical ? 15 : 0
-        collectionViewRightPadding = isVertical ? 0 : collectionViewLeftPadding
-        collectionView.isUserInteractionEnabled = !isVertical
-        questionButton.isHidden = poll.state == .shared || isVertical || isMember
-        timerLabel.isHidden = !(poll.state == .live) || isVertical || isMember
+        questionButton.isHidden = poll.state == .shared || isMember
+        timerLabel.isHidden = !(poll.state == .live) || isMember
         if poll.state == .live {
             questionButton.setTitle(endQuestionText, for: .normal)
             timerLabel.text = initialTimerLabelText
@@ -308,10 +287,6 @@ extension CardCell: FRInputSectionControllerDelegate {
 }
 
 extension CardCell: PollOptionsSectionControllerDelegate {
-    
-    var cardControllerState: CardControllerState {
-        return delegate.cardControllerState
-    }
     
     var userRole: UserRole {
         return delegate.userRole

--- a/Clicker/Views/Cards/EmptyStateCell.swift
+++ b/Clicker/Views/Cards/EmptyStateCell.swift
@@ -169,7 +169,7 @@ class EmptyStateCell: UICollectionViewCell {
             iconImageView.image = #imageLiteral(resourceName: "shrug_emoji")
             titleLabel.textColor = .black
             let pollTypeString = pollType == .created ? "created" : "joined"
-            titleLabel.text = "No polls \(pollTypeString)"
+            titleLabel.text = "No groups \(pollTypeString)"
             subtitleLabel.text = pollType == .created ? createNewQuestionText : enterCodeText
             break
         case .cardController(let userRole):

--- a/Clicker/Views/Cards/EmptyStateCell.swift
+++ b/Clicker/Views/Cards/EmptyStateCell.swift
@@ -41,7 +41,7 @@ class EmptyStateCell: UICollectionViewCell {
     let createDraftButtonHeight: CGFloat = 47
     let zoomTimeInterval: TimeInterval = 0.35
     let zoomInScale: CGFloat = 0.85
-    let createNewQuestionText = "Create a new question above!"
+    let createNewGroupText = "Create a new group above!"
     let enterCodeText = "Enter a code below to join!"
     let adminNothingToSeeText = "Nothing to see here."
     let userNothingToSeeText = "Nothing to see yet."
@@ -170,7 +170,7 @@ class EmptyStateCell: UICollectionViewCell {
             titleLabel.textColor = .black
             let pollTypeString = pollType == .created ? "created" : "joined"
             titleLabel.text = "No groups \(pollTypeString)"
-            subtitleLabel.text = pollType == .created ? createNewQuestionText : enterCodeText
+            subtitleLabel.text = pollType == .created ? createNewGroupText : enterCodeText
             break
         case .cardController(let userRole):
             if let session = session, let shouldDisplayNameView = shouldDisplayNameView, let nameViewDelegate = nameViewDelegate, shouldDisplayNameView {

--- a/Clicker/Views/Cards/PollMiscellaneousCell.swift
+++ b/Clicker/Views/Cards/PollMiscellaneousCell.swift
@@ -19,6 +19,7 @@ class PollMiscellaneousCell: UICollectionViewCell {
     let iconImageViewLength: CGFloat = 15
     let descriptionLabelXPadding: CGFloat = 10
     let totalVotesLabelTrailingPadding: CGFloat = 14
+    let labelFontSize: CGFloat = 12
     let endedDescriptionText = "Only you can see results"
     let sharedDescriptionText = "Shared with group"
     
@@ -38,12 +39,12 @@ class PollMiscellaneousCell: UICollectionViewCell {
         
         descriptionLabel = UILabel()
         descriptionLabel.textColor = .clickerGrey2
-        descriptionLabel.font = UIFont.systemFont(ofSize: 10, weight: .semibold)
+        descriptionLabel.font = UIFont.systemFont(ofSize: labelFontSize, weight: .semibold)
         contentView.addSubview(descriptionLabel)
         
         totalVotesLabel = UILabel()
         totalVotesLabel.textColor = .clickerGrey2
-        totalVotesLabel.font = UIFont.systemFont(ofSize: 10, weight: .semibold)
+        totalVotesLabel.font = UIFont.systemFont(ofSize: labelFontSize, weight: .semibold)
         contentView.addSubview(totalVotesLabel)
     }
     

--- a/Clicker/Views/Cards/PollOptionsCell.swift
+++ b/Clicker/Views/Cards/PollOptionsCell.swift
@@ -11,7 +11,6 @@ import IGListKit
 
 protocol PollOptionsCellDelegate {
     
-    var cardControllerState: CardControllerState { get }
     var userRole: UserRole { get }
     
     func pollOptionsCellDidSubmitChoice(choice: String)
@@ -105,10 +104,6 @@ extension PollOptionsCell: ListAdapterDataSource {
 }
 
 extension PollOptionsCell: MCResultSectionControllerDelegate, FROptionSectionControllerDelegate {
-    
-    var cardControllerState: CardControllerState {
-        return delegate.cardControllerState
-    }
     
     var userRole: UserRole {
         return delegate.userRole

--- a/Clicker/Views/Cards/QuestionCell.swift
+++ b/Clicker/Views/Cards/QuestionCell.swift
@@ -12,10 +12,9 @@ class QuestionCell: UICollectionViewCell {
     
     // MARK: - View vars
     var questionLabel: UILabel!
-    var moreButton: UIButton!
     
     // MARK: - Constants
-    let horizontalPadding: CGFloat = 14
+    let horizontalPadding: CGFloat = 18
     let questionLabelWidthScaleFactor: CGFloat = 0.75
     let moreButtonWidth: CGFloat = 25
     
@@ -33,24 +32,13 @@ class QuestionCell: UICollectionViewCell {
         questionLabel.numberOfLines = 0
         questionLabel.lineBreakMode = .byWordWrapping
         contentView.addSubview(questionLabel)
-        
-        moreButton = UIButton()
-        moreButton.setImage(#imageLiteral(resourceName: "dots"), for: .normal)
-        moreButton.contentMode = .scaleAspectFit
-        contentView.addSubview(moreButton)
     }
     
     override func updateConstraints() {
         questionLabel.snp.makeConstraints { make in
             make.leading.equalToSuperview().offset(horizontalPadding)
-            make.width.equalToSuperview().multipliedBy(questionLabelWidthScaleFactor)
-            make.top.equalToSuperview()
-        }
-        
-        moreButton.snp.makeConstraints { make in
-            make.width.equalTo(moreButtonWidth)
             make.trailing.equalToSuperview().inset(horizontalPadding)
-            make.centerY.equalToSuperview()
+            make.top.equalToSuperview()
         }
         super.updateConstraints()
     }

--- a/Clicker/Views/HomeScreen/Polls/PollsCell+Extension.swift
+++ b/Clicker/Views/HomeScreen/Polls/PollsCell+Extension.swift
@@ -43,7 +43,8 @@ extension PollsCell: SessionSectionControllerDelegate {
     }
     
     func sessionSectionControllerShouldEditSession(sectionController: SessionSectionController, session: Session) {
-        delegate.pollsCellShouldEditSession(session: session)
+        let userRole: UserRole = pollType == .created ? .admin : .member
+        delegate.pollsCellShouldEditSession(session: session, userRole: userRole)
     }
     
 }

--- a/Clicker/Views/HomeScreen/Polls/PollsCell.swift
+++ b/Clicker/Views/HomeScreen/Polls/PollsCell.swift
@@ -14,7 +14,7 @@ import UIKit
 protocol PollsCellDelegate {
     
     func pollsCellShouldOpenSession(session: Session, userRole: UserRole)
-    func pollsCellShouldEditSession(session: Session)
+    func pollsCellShouldEditSession(session: Session, userRole: UserRole)
     
 }
 


### PR DESCRIPTION
This PR fixes:
- When I try to delete a group that I’ve created … It says “Deleting will permanently close the group for all participants and all poll data will be lost” … we only want that to be the case for groups that I’ve created … for groups that are joined we should only be leaving them as a member … 
- When I join a group using a code … the code remains in that text field 
- Buttons on the Edit Session are too close to bottom on iPhoneX
- Delete (…) button for poll
- The only two concepts that the user should be aware of are “Groups” and “Polls” @Kevin C make sure we don’t see any other names in the app besides those two

In terms of app structure changes:
- When joining a group → show sessions screen (the dates w/ number of question for each date) → then clicking on a date should show a new screen of the polls for that day
    - Did this by separating CardController -> PollsDateViewController (the sessions screen) and Card Controller