### PR TITLE
bug fixes pt 126

### DIFF
--- a/Clicker/Extensions/Utils.swift
+++ b/Clicker/Extensions/Utils.swift
@@ -60,18 +60,21 @@ func calculatePollOptionsCellHeight(for pollOptionsModel: PollOptionsModel) -> C
     let verticalPadding: CGFloat = LayoutConstants.pollOptionsVerticalPadding * 2
     var optionModels: [OptionModel]
     var optionHeight: CGFloat
+    var maximumNumberVisibleOptions: Int
     switch pollOptionsModel.type {
     case .mcResult(let mcResultModels):
         optionModels = mcResultModels
         optionHeight = LayoutConstants.mcOptionCellHeight
+        maximumNumberVisibleOptions = 6
     case .mcChoice(let mcChoiceModels):
         optionModels = mcChoiceModels
         optionHeight = LayoutConstants.mcOptionCellHeight
+        maximumNumberVisibleOptions = 6
     case .frOption(let frOptionModels):
         optionModels = frOptionModels
         optionHeight = LayoutConstants.frOptionCellHeight
+        maximumNumberVisibleOptions = 5
     }
-    let maximumNumberVisibleOptions = 6
     let numOptions = min(optionModels.count, maximumNumberVisibleOptions)
     let optionsHeight: CGFloat = CGFloat(numOptions) * optionHeight
     return verticalPadding + optionsHeight

--- a/Clicker/Models/ListDiffableModels/PollMiscellaneousModel.swift
+++ b/Clicker/Models/ListDiffableModels/PollMiscellaneousModel.swift
@@ -10,11 +10,13 @@ import IGListKit
 
 class PollMiscellaneousModel {
     
+    var questionType: QuestionType!
     var pollState: PollState
     var totalVotes: Int
     let identifier = UUID().uuidString
     
-    init(pollState: PollState, totalVotes: Int) {
+    init(questionType: QuestionType, pollState: PollState, totalVotes: Int) {
+        self.questionType = questionType
         self.pollState = pollState
         self.totalVotes = totalVotes
     }

--- a/Clicker/Supporting/Constants.swift
+++ b/Clicker/Supporting/Constants.swift
@@ -80,7 +80,7 @@ struct LayoutConstants {
     static let pollMiscellaneousCellHeight: CGFloat = 30
     static let pollOptionsVerticalPadding: CGFloat = 10
     static let cardHorizontalPadding: CGFloat = 14
-    static let questionCellHeight: CGFloat = 46
+    static let questionCellHeight: CGFloat = 60
     static let pollBuilderCVHorizontalInset: CGFloat = 18
     static let separatorLineCellHeight: CGFloat = 1
     static let buttonImageInsets = UIEdgeInsets(top: 13, left: 13, bottom: 13, right: 13)

--- a/Clicker/ViewControllers/PollsViewController.swift
+++ b/Clicker/ViewControllers/PollsViewController.swift
@@ -122,8 +122,7 @@ class PollsViewController: UIViewController {
         dimmingView = UIView()
         dimmingView.translatesAutoresizingMaskIntoConstraints = false
         dimmingView.backgroundColor = UIColor(white: 0.0, alpha: 0.5)
-        dimmingView.alpha = 1.0
-        dimmingView.isHidden = true
+        dimmingView.alpha = 0
         view.addSubview(dimmingView)
         
         joinSessionContainerView = UIView()
@@ -346,7 +345,9 @@ class PollsViewController: UIViewController {
         if !isListeningToKeyboard || hasPresentedViewController { return }
         if let keyboardSize = (notification.userInfo?[UIKeyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
             let iphoneXBottomPadding = view.safeAreaInsets.bottom
-            dimmingView.isHidden = false
+            UIView.animate(withDuration: 0.5) {
+                self.dimmingView.alpha = 1
+            }
             joinSessionContainerView.snp.remakeConstraints { make in
                 make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(keyboardSize.height - iphoneXBottomPadding)
                 make.leading.trailing.equalToSuperview()
@@ -361,7 +362,9 @@ class PollsViewController: UIViewController {
         let hasPresentedViewController = self.presentedViewController != nil && !(self.presentedViewController is UIAlertController)
         if !isListeningToKeyboard || hasPresentedViewController { return }
         if let _ = (notification.userInfo?[UIKeyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue {
-            dimmingView.isHidden = true
+            UIView.animate(withDuration: 0.5) {
+                self.dimmingView.alpha = 0
+            }
             joinSessionContainerView.snp.remakeConstraints { make in
                 make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
                 make.leading.trailing.equalToSuperview()

--- a/Clicker/Views/Cards/CardCell.swift
+++ b/Clicker/Views/Cards/CardCell.swift
@@ -52,7 +52,7 @@ class CardCell: UICollectionViewCell {
     let questionButtonHeight: CGFloat = 47.0
     let questionButtonBottomPadding: CGFloat = 10.0
     let timerLabelFontSize: CGFloat = 14.0
-    let timerLabelBottomPadding: CGFloat =  50.0
+    let timerLabelBottomPadding: CGFloat =  30.0
     let endQuestionText = "End Question"
     let shareResultsText = "Share Results"
     let initialTimerLabelText = "00:00"
@@ -74,7 +74,7 @@ class CardCell: UICollectionViewCell {
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.showsVerticalScrollIndicator = false
         collectionView.showsHorizontalScrollIndicator = false
-        collectionView.bounces = false
+        collectionView.bounces = true
         collectionView.backgroundColor = .clear
         contentView.addSubview(collectionView)
         
@@ -138,7 +138,7 @@ class CardCell: UICollectionViewCell {
         
         questionModel = QuestionModel(question: poll.text)
         pollOptionsModel = buildPollOptionsModel(from: poll, userRole: userRole)
-        miscellaneousModel = PollMiscellaneousModel(pollState: poll.state, totalVotes: poll.getTotalResults())
+        miscellaneousModel = PollMiscellaneousModel(questionType: poll.questionType, pollState: poll.state, totalVotes: poll.getTotalResults())
         adapter.performUpdates(animated: false, completion: nil)
     }
     
@@ -148,13 +148,13 @@ class CardCell: UICollectionViewCell {
             poll.state = .ended
             questionButton.setTitle(shareResultsText, for: .normal)
             timerLabel.isHidden = true
-            miscellaneousModel = PollMiscellaneousModel(pollState: .ended, totalVotes: miscellaneousModel.totalVotes)
+            miscellaneousModel = PollMiscellaneousModel(questionType: poll.questionType, pollState: .ended, totalVotes: miscellaneousModel.totalVotes)
             adapter.performUpdates(animated: false, completion: nil)
             delegate.cardCellDidEndPoll(cardCell: self, poll: poll)
         } else if poll.state == .ended {
             poll.state = .shared
             questionButton.isHidden = true
-            miscellaneousModel = PollMiscellaneousModel(pollState: .shared, totalVotes: miscellaneousModel.totalVotes)
+            miscellaneousModel = PollMiscellaneousModel(questionType: poll.questionType, pollState: .shared, totalVotes: miscellaneousModel.totalVotes)
             adapter.performUpdates(animated: false, completion: nil)
             delegate.cardCellDidShareResults(cardCell: self, poll: poll)
         }

--- a/Clicker/Views/Cards/PollMiscellaneousCell.swift
+++ b/Clicker/Views/Cards/PollMiscellaneousCell.swift
@@ -21,7 +21,8 @@ class PollMiscellaneousCell: UICollectionViewCell {
     let labelFontSize: CGFloat = 12
     let liveEndedDescriptionText = "Only you can see results"
     let sharedDescriptionText = "Shared with group"
-    
+    let voteString = "vote"
+    let responseString = "response"
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -76,7 +77,14 @@ class PollMiscellaneousCell: UICollectionViewCell {
             iconImageView.image = #imageLiteral(resourceName: "results_shared")
             descriptionLabel.text = sharedDescriptionText
         }
-        totalVotesLabel.text = miscellaneousModel.totalVotes == 1 ? "1 vote" : "\(miscellaneousModel.totalVotes) votes"
+        var unit: String
+        switch miscellaneousModel.questionType! {
+        case .multipleChoice:
+            unit = miscellaneousModel.totalVotes == 1 ? voteString : "\(voteString)s"
+        case .freeResponse:
+            unit = miscellaneousModel.totalVotes == 1 ? responseString : "\(responseString)s"
+        }
+        totalVotesLabel.text = "\(miscellaneousModel.totalVotes) \(unit)"
     }
     
     required init?(coder aDecoder: NSCoder) {

--- a/Clicker/Views/Cards/PollOptionsCell.swift
+++ b/Clicker/Views/Cards/PollOptionsCell.swift
@@ -40,9 +40,9 @@ class PollOptionsCell: UICollectionViewCell {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        collectionView.showsVerticalScrollIndicator = false
+        collectionView.showsVerticalScrollIndicator = true
         collectionView.showsHorizontalScrollIndicator = false
-        collectionView.bounces = false
+        collectionView.alwaysBounceVertical = true
         collectionView.backgroundColor = .clear
         contentView.addSubview(collectionView)
         

--- a/Clicker/Views/Cards/QuestionCell.swift
+++ b/Clicker/Views/Cards/QuestionCell.swift
@@ -30,7 +30,8 @@ class QuestionCell: UICollectionViewCell {
         questionLabel = UILabel()
         questionLabel.font = UIFont.systemFont(ofSize: questionLabelFontSize, weight: .heavy)
         questionLabel.numberOfLines = 0
-        questionLabel.lineBreakMode = .byWordWrapping
+        questionLabel.lineBreakMode = .byTruncatingTail
+        questionLabel.numberOfLines = 2
         contentView.addSubview(questionLabel)
     }
     


### PR DESCRIPTION
Fixes some bugs on the bugs list

- adding many options for free response makes the card cover the share results button (same for MC)
- Question spacing when it goes over two lines
- Make MC Options and FR Options scroll view bouncy and show scroll bar on the side for that 
- Make EndQuestion Button and timer lower
- Change “X votes” to “X responses” for free response questions
- Background overlay when Join Bar is activated should fade in more gradually, not suddenly appear