### PR TITLE
Added fabric logging template

### DIFF
--- a/Clicker.xcodeproj/project.pbxproj
+++ b/Clicker.xcodeproj/project.pbxproj
@@ -111,6 +111,8 @@
 		C2D0579B1F926BB4008F21CB /* Answer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D0579A1F926BB4008F21CB /* Answer.swift */; };
 		C2E1A2642139F0E500087EE4 /* MCResultSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E1A2632139F0E500087EE4 /* MCResultSectionController.swift */; };
 		C2E1A2662139F43400087EE4 /* PollMiscellaneousModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E1A2652139F43400087EE4 /* PollMiscellaneousModel.swift */; };
+		C2E9C7092182A40600E36659 /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E9C7082182A40600E36659 /* Analytics.swift */; };
+		C2E9C70B2182ACCE00E36659 /* EventPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E9C70A2182ACCE00E36659 /* EventPayload.swift */; };
 		C2F48EB3208302AE0022FE6B /* Draft.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F48EB2208302AE0022FE6B /* Draft.swift */; };
 		C2F48EB7208302F90022FE6B /* Socket.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F48EB6208302F90022FE6B /* Socket.swift */; };
 		C2F48EB9208303020022FE6B /* SocketDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F48EB8208303020022FE6B /* SocketDelegate.swift */; };
@@ -246,6 +248,8 @@
 		C2D0579A1F926BB4008F21CB /* Answer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Answer.swift; sourceTree = "<group>"; };
 		C2E1A2632139F0E500087EE4 /* MCResultSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCResultSectionController.swift; sourceTree = "<group>"; };
 		C2E1A2652139F43400087EE4 /* PollMiscellaneousModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollMiscellaneousModel.swift; sourceTree = "<group>"; };
+		C2E9C7082182A40600E36659 /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
+		C2E9C70A2182ACCE00E36659 /* EventPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventPayload.swift; sourceTree = "<group>"; };
 		C2F48EB2208302AE0022FE6B /* Draft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Draft.swift; sourceTree = "<group>"; };
 		C2F48EB6208302F90022FE6B /* Socket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Socket.swift; sourceTree = "<group>"; };
 		C2F48EB8208303020022FE6B /* SocketDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketDelegate.swift; sourceTree = "<group>"; };
@@ -542,6 +546,8 @@
 				C7F923CC1F73540600B1E975 /* Assets.xcassets */,
 				C7F923CE1F73540600B1E975 /* LaunchScreen.storyboard */,
 				C7D6AF581F93DE4E003ABA10 /* Constants.swift */,
+				C2E9C7082182A40600E36659 /* Analytics.swift */,
+				C2E9C70A2182ACCE00E36659 /* EventPayload.swift */,
 			);
 			path = Supporting;
 			sourceTree = "<group>";
@@ -881,10 +887,12 @@
 				C2434CBF21388E2B00929C98 /* Poll.swift in Sources */,
 				C20B571D2139E6080091034F /* MCResultCell.swift in Sources */,
 				63ACEC74214B401600D555F1 /* SettingsSectionController.swift in Sources */,
+				C2E9C70B2182ACCE00E36659 /* EventPayload.swift in Sources */,
 				C275A1BE2098BE9100815951 /* EditPollViewController.swift in Sources */,
 				C2F48EBF208304980022FE6B /* SessionQuark.swift in Sources */,
 				C20B57192139DDA10091034F /* QuestionSectionController.swift in Sources */,
 				C26D5F51214F5F3700548255 /* PollsDateSectionController.swift in Sources */,
+				C2E9C7092182A40600E36659 /* Analytics.swift in Sources */,
 				C2F48EC32083051A0022FE6B /* PollsViewController.swift in Sources */,
 				63ACEC70214B378E00D555F1 /* SettingsViewController.swift in Sources */,
 				63ACEC72214B3D2A00D555F1 /* SettingsDataModel.swift in Sources */,

--- a/Clicker/Supporting/Analytics.swift
+++ b/Clicker/Supporting/Analytics.swift
@@ -1,0 +1,64 @@
+//
+//  Analytics.swift
+//  Clicker
+//
+//  Created by Kevin Chan on 10/25/18.
+//  Copyright © 2018 CornellAppDev. All rights reserved.
+//
+
+/// Logging based on TCAT-ios
+
+import Crashlytics
+import SwiftyJSON
+
+class Analytics {
+    static let shared = Analytics()
+
+    func log(with payload: Payload) {
+        let fabricEvent = payload.convertToFabric()
+        Answers.logCustomEvent(withName: fabricEvent.name, customAttributes: fabricEvent.attributes)
+        print("Logging \(fabricEvent.name):\(fabricEvent.attributes ?? [:])")
+    }
+}
+
+/// Log Device Information
+struct DeviceInfo: Codable {
+    let model = Device.modelName
+    let appVersion = App.version
+}
+
+// MARK: - Payloads
+extension Payload {
+
+    func convertToFabric() -> (name: String, attributes: [String : Any]?) {
+        let event = self.toEvent()
+        do {
+            let data = try event.serializeJson()
+            let json = try JSON(data: data)
+
+            var dict: [String : Any] = [:]
+            for (key, value) in json["payload"] {
+                if key == "deviceInfo" {
+                    for (infoKey, infoValue) in value {
+                        dict[infoKey] = infoValue.stringValue
+                    }
+                } else {
+                    dict[key] = value.stringValue
+                }
+            }
+
+            return(name: json["event_type"].stringValue, dict)
+        } catch {
+            print("error here!")
+            return ("", nil)
+        }
+    }
+
+}
+
+struct GroupCreatedPayload: Payload {
+    static let eventName: String = "Group Created"
+    let deviceInfo = DeviceInfo()
+
+    let code: String
+}

--- a/Clicker/Supporting/Constants.swift
+++ b/Clicker/Supporting/Constants.swift
@@ -133,6 +133,13 @@ enum Keys: String {
     }()
 }
 
+struct App {
+
+    /// The app version within the App Store (e.g. "1.4.2") [String value of `CFBundleShortVersionString`]
+    static let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0"
+
+}
+
 struct Device {
     static let id: String = {
         if let deviceId = UIDevice.current.identifierForVendor?.uuidString {
@@ -141,6 +148,8 @@ struct Device {
             return UUID().uuidString
         }
     }()
+
+    static let modelName = UIDevice.current.model
     
     private init() {}
 }

--- a/Clicker/Supporting/EventPayload.swift
+++ b/Clicker/Supporting/EventPayload.swift
@@ -1,0 +1,56 @@
+//
+//  EventPayload.swift
+//  Clicker
+//
+//  Created by Kevin Chan on 10/25/18.
+//  Copyright © 2018 CornellAppDev. All rights reserved.
+//
+
+/// Logging based on TCAT-ios
+
+import Foundation
+
+public protocol Payload: Codable {
+    static var eventName: String {get}
+}
+
+public extension Payload {
+    public func toEvent() -> Event<Self> {
+        return Event(payload: self)
+    }
+}
+
+/**Use JSONData for serialized JSON*/
+public typealias JSONData = Data
+
+public class Event<TPayload: Payload>: Codable {
+    public let payload: TPayload
+    public var eventName: String {return TPayload.eventName}
+
+    init(payload: TPayload) {
+        self.payload = payload
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        self.payload = try values.decode(TPayload.self, forKey: .payload)
+        let decodedEventName = try values.decode(String.self, forKey: .eventName)
+        if decodedEventName != eventName {
+            throw NSError()
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var values = encoder.container(keyedBy: CodingKeys.self)
+        try values.encode(self.payload, forKey: .payload)
+        try values.encode(self.eventName, forKey: .eventName)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case timestamp, payload, eventName = "event_type"
+    }
+
+    public func serializeJson() throws -> JSONData {
+        return try JSONEncoder().encode(self)
+    }
+}


### PR DESCRIPTION
Added structure for fabric logging based on TCAT-ios logging

Steps:
1) Create a new `Payload` type
2) Log using `Analytics.shared.log(...)`