### PR TITLE
Fix duplicate selected mc choice bug

### DIFF
--- a/Clicker/Models/ListDiffableModels/Poll.swift
+++ b/Clicker/Models/ListDiffableModels/Poll.swift
@@ -143,6 +143,13 @@ class Poll {
         return false
     }
 
+    func updateSelected(mcChoice: String) {
+        selectedMCChoice = mcChoice
+        if let userId = User.currentUser?.id {
+            answers[userId] = mcChoice
+        }
+    }
+
 }
 
 extension Poll: ListDiffable {

--- a/Clicker/SectionControllers/PollSectionController.swift
+++ b/Clicker/SectionControllers/PollSectionController.swift
@@ -63,7 +63,7 @@ extension PollSectionController: CardCellDelegate {
     }
     
     func cardCellDidSubmitChoice(cardCell: CardCell, choice: String) {
-        poll.selectedMCChoice = choice
+        poll.updateSelected(mcChoice: choice)
         delegate.pollSectionControllerDidSubmitChoiceForPoll(sectionController: self, choice: choice, poll: poll)
     }
 


### PR DESCRIPTION
- Submit MC Choice → Leave Session → Go back into Session and choose new MC Choice. When admin ends poll, it shows multiple choices selected.