### PR TITLE
Add spacing in people button in CardController view

### DIFF
--- a/Clicker/ViewControllers/CardController.swift
+++ b/Clicker/ViewControllers/CardController.swift
@@ -175,6 +175,8 @@ class CardController: UIViewController {
         peopleButton.setImage(#imageLiteral(resourceName: "person"), for: .normal)
         peopleButton.setTitle("\(numberOfPeople ?? 0)", for: .normal)
         peopleButton.titleLabel?.font = UIFont._16RegularFont
+        peopleButton.contentEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: 5)
+        peopleButton.imageEdgeInsets = UIEdgeInsets(top: 0, left: -5, bottom: 0, right: 5)
         peopleButton.sizeToFit()
         let peopleBarButton = UIBarButtonItem(customView: peopleButton)
         


### PR DESCRIPTION
• Added edge insets to content and image of people icon to increase spacing between number of people joined and icon in the CardController view
• I had previously edited the people button spacing in the PollsDateViewController view but did not apply the change to the CardController view so I added that just now.

<img width="385" alt="screen shot 2019-02-21 at 11 54 20 am" src="https://user-images.githubusercontent.com/29307883/53187107-5fe7b080-35d0-11e9-9ac1-0fa10c7c2e7b.png">
