### PR TITLE
Change to 8 pt grid and update settings view

### DIFF
--- a/Clicker.xcodeproj/project.pbxproj
+++ b/Clicker.xcodeproj/project.pbxproj
@@ -154,6 +154,7 @@
 		C7F923C61F73540600B1E975 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F923C51F73540600B1E975 /* AppDelegate.swift */; };
 		D13E908B2086BC3200856DD4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C7F923CE1F73540600B1E975 /* LaunchScreen.storyboard */; };
 		D13E9092208712A300856DD4 /* PollBuilderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13E9091208712A300856DD4 /* PollBuilderViewController.swift */; };
+		D412ACD02246EDAA009B6E83 /* SettingsLogOutButtonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D412ACCF2246EDAA009B6E83 /* SettingsLogOutButtonCell.swift */; };
 		D946CA7E221346860005AD70 /* keys.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = D946CA7D221346860005AD70 /* keys.generated.swift */; };
 		D946CA822213D2EA0005AD70 /* testflight_release_notes.txt in Resources */ = {isa = PBXBuildFile; fileRef = D946CA812213D2EA0005AD70 /* testflight_release_notes.txt */; };
 /* End PBXBuildFile section */
@@ -323,6 +324,7 @@
 		C7F923CF1F73540600B1E975 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C7F923D11F73540600B1E975 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D13E9091208712A300856DD4 /* PollBuilderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollBuilderViewController.swift; sourceTree = "<group>"; };
+		D412ACCF2246EDAA009B6E83 /* SettingsLogOutButtonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsLogOutButtonCell.swift; sourceTree = "<group>"; };
 		D946CA7D221346860005AD70 /* keys.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = keys.generated.swift; sourceTree = "<group>"; };
 		D946CA812213D2EA0005AD70 /* testflight_release_notes.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = testflight_release_notes.txt; sourceTree = "<group>"; };
 		F8BCD96EC847A3A4C51959E6 /* Pods-Clicker.debug local server.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Clicker.debug local server.xcconfig"; path = "Pods/Target Support Files/Pods-Clicker/Pods-Clicker.debug local server.xcconfig"; sourceTree = "<group>"; };
@@ -476,6 +478,7 @@
 			children = (
 				63ACEC76214D61A000D555F1 /* SettingsInfoCell.swift */,
 				63ACEC78214D61BE00D555F1 /* SettingsLinkCell.swift */,
+				D412ACCF2246EDAA009B6E83 /* SettingsLogOutButtonCell.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -993,6 +996,7 @@
 				C25F21EA203F77FA001F540E /* AnswerMCCell.swift in Sources */,
 				C271A0822193F80400EF12B4 /* ViewAllSectionController.swift in Sources */,
 				C270524C209D51A600C7980F /* CardController+Extension.swift in Sources */,
+				D412ACD02246EDAA009B6E83 /* SettingsLogOutButtonCell.swift in Sources */,
 				0C8AE5D9215AD33300D54A36 /* EditDraftViewController.swift in Sources */,
 				C2BF44D02033FD630067505A /* UIViewController+Shared.swift in Sources */,
 				C2BF982B206BE1240048468E /* OptionsView.swift in Sources */,

--- a/Clicker/Models/ListDiffableModels/SettingsDataModel.swift
+++ b/Clicker/Models/ListDiffableModels/SettingsDataModel.swift
@@ -9,7 +9,7 @@
 import IGListKit
 
 enum SettingsDataState {
-    case link, info
+    case link, info, button
 }
 
 class SettingsDataModel {

--- a/Clicker/Models/Socket.swift
+++ b/Clicker/Models/Socket.swift
@@ -118,13 +118,6 @@ class Socket {
             self.delegate?.pollEnded(poll, userRole: .admin)
         }
         
-        socket.on(Routes.count) { data, _ in
-            guard let json = data[0] as? [String: Any], let count = json[ParserKeys.countKey] as? Int else {
-                return
-            }
-            self.delegate?.receivedUserCount(count)
-        }
-
         socket.connect()
     }
 

--- a/Clicker/Models/SocketDelegate.swift
+++ b/Clicker/Models/SocketDelegate.swift
@@ -7,11 +7,11 @@
 //
 
 protocol SocketDelegate: class {
+
     func pollDeleted(_ pollID: Int, userRole: UserRole)
     func pollDeletedLive()
     func pollEnded(_ poll: Poll, userRole: UserRole)
     func pollStarted(_ poll: Poll, userRole: UserRole)
-    func receivedUserCount(_ count: Int)
     func sessionConnected()
     func sessionDisconnected()
     func sessionErrored()

--- a/Clicker/Models/User.swift
+++ b/Clicker/Models/User.swift
@@ -55,9 +55,9 @@ struct UserSession: Codable {
     let accessToken: String
     let isActive: Bool
     let refreshToken: String
-    let sessionExpiration: Int
+    let sessionExpiration: String
     
-    init(accessToken: String, refreshToken: String, sessionExpiration: Int, isActive: Bool) {
+    init(accessToken: String, refreshToken: String, sessionExpiration: String, isActive: Bool) {
         self.accessToken = accessToken
         self.isActive = isActive
         self.refreshToken = refreshToken

--- a/Clicker/SectionControllers/SettingsSectionControllers/SettingsSectionController.swift
+++ b/Clicker/SectionControllers/SettingsSectionControllers/SettingsSectionController.swift
@@ -8,15 +8,27 @@
 
 import IGListKit
 
+protocol LogOutSectionControllerDelegate: class {
+    func logOutSectionControllerButtonWasTapped()
+}
+
 class SettingsSectionController: ListSectionController {
     
     var settingsDataModel: SettingsDataModel!
     
+    // MARK: Data vars
+    weak var delegate: LogOutSectionControllerDelegate?
+    
     // MARK: Layout constants
     let aboutInfoCellHeight: CGFloat = 110.0
     let accountInfoCellHeight: CGFloat = 80.0
+    let buttonCellHeight: CGFloat = 39.5
     let feedbackInfoCellHeight: CGFloat = 130
     let linkCellHeight: CGFloat = 39.5
+    
+    init(delegate: LogOutSectionControllerDelegate) {
+        self.delegate = delegate
+    }
     
     // MARK: - ListSectionController overrides
     override func sizeForItem(at index: Int) -> CGSize {
@@ -37,7 +49,10 @@ class SettingsSectionController: ListSectionController {
             return CGSize(width: containerSize.width, height: cellHeight)
         case .link:
             return CGSize(width: containerSize.width, height: linkCellHeight)
+        case .button:
+            return CGSize(width: containerSize.width, height: buttonCellHeight)
         }
+
     }
     
     override func cellForItem(at index: Int) -> UICollectionViewCell {
@@ -55,6 +70,11 @@ class SettingsSectionController: ListSectionController {
             let cell = collectionContext?.dequeueReusableCell(of: SettingsLinkCell.self, for: self, at: index) as! SettingsLinkCell
             cell.configureWith(settingsDataModel: settingsDataModel)
             return cell
+        case .button:
+            let cell = collectionContext?.dequeueReusableCell(of: SettingsLogOutButtonCell.self, for: self, at: index) as! SettingsLogOutButtonCell
+            cell.configureWith(settingsDataModel: settingsDataModel)
+            cell.delegate = self
+            return cell
         }
     }
     
@@ -62,4 +82,13 @@ class SettingsSectionController: ListSectionController {
         settingsDataModel = object as? SettingsDataModel
     }
 
+}
+
+// MARK: - LogoutButtonCellDelegate
+extension SettingsSectionController: LogoutButtonCellDelegate {
+    
+    func logOutButtonCellWasTapped() {
+        delegate?.logOutSectionControllerButtonWasTapped()
+    }
+    
 }

--- a/Clicker/ViewControllers/CardController.swift
+++ b/Clicker/ViewControllers/CardController.swift
@@ -53,7 +53,7 @@ class CardController: UIViewController {
     
     // MARK: - Constants
     let collectionViewHorizontalInset: CGFloat = 9.0
-    let collectionViewTopPadding: CGFloat = 7
+    let collectionViewTopPadding: CGFloat = 16.0
     let countLabelBackgroundViewTopPadding: CGFloat = 24
     let countLabelHeight: CGFloat = 21.0
     let countLabelHorizontalPadding: CGFloat = 2.5
@@ -167,24 +167,14 @@ class CardController: UIViewController {
         let backImage = UIImage(named: "back")?.withRenderingMode(.alwaysOriginal)
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: backImage, style: .done, target: self, action: #selector(goBack))
         
-        peopleButton = UIButton()
-        peopleButton.setImage(#imageLiteral(resourceName: "person"), for: .normal)
-        peopleButton.setTitle("\(numberOfPeople ?? 0)", for: .normal)
-        peopleButton.titleLabel?.font = UIFont._16RegularFont
-        peopleButton.contentEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: 5)
-        peopleButton.imageEdgeInsets = UIEdgeInsets(top: 0, left: -5, bottom: 0, right: 5)
-        peopleButton.sizeToFit()
-        let peopleBarButton = UIBarButtonItem(customView: peopleButton)
-        
         if userRole == .admin {
             createPollButton = UIButton()
             createPollButton.setImage(#imageLiteral(resourceName: "whiteCreatePoll"), for: .normal)
             createPollButton.addTarget(self, action: #selector(createPollBtnPressed), for: .touchUpInside)
-          let createPollBarButton = UIBarButtonItem(customView: createPollButton)
-            self.navigationItem.rightBarButtonItems = [createPollBarButton, peopleBarButton]
-        } else {
-            self.navigationItem.rightBarButtonItems = [peopleBarButton]
+            let createPollBarButton = UIBarButtonItem(customView: createPollButton)
+            self.navigationItem.rightBarButtonItems = [createPollBarButton]
         }
+
     }
     
     // MARK: Helpers

--- a/Clicker/ViewControllers/PollsDateViewController+Extension.swift
+++ b/Clicker/ViewControllers/PollsDateViewController+Extension.swift
@@ -47,8 +47,6 @@ extension PollsDateViewController: CardControllerDelegate {
 
     func cardControllerWillDisappear(with pollsDateModel: PollsDateModel, numberOfPeople: Int) {
         self.numberOfPeople = numberOfPeople
-        peopleButton.setTitle("\(numberOfPeople)", for: .normal)
-        peopleButton.sizeToFit()
         if let indexOfPollsDateModel = pollsDateArray.firstIndex(where: { $0.date == pollsDateModel.date }) {
             pollsDateArray[indexOfPollsDateModel] = PollsDateModel(date: pollsDateModel.date, polls: pollsDateModel.polls)
             adapter.performUpdates(animated: false, completion: nil)
@@ -170,12 +168,6 @@ extension PollsDateViewController: SocketDelegate {
                 self.present(alertController, animated: true, completion: nil)
             }
         }
-    }
-    
-    func receivedUserCount(_ count: Int) {
-        numberOfPeople = count
-        peopleButton.setTitle("\(count)", for: .normal)
-        peopleButton.sizeToFit()
     }
     
     func pollStarted(_ poll: Poll, userRole: UserRole) {

--- a/Clicker/ViewControllers/PollsDateViewController.swift
+++ b/Clicker/ViewControllers/PollsDateViewController.swift
@@ -108,24 +108,12 @@ class PollsDateViewController: UIViewController {
         let backImage = UIImage(named: "back")?.withRenderingMode(.alwaysOriginal)
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: backImage, style: .done, target: self, action: #selector(goBack))
         
-        peopleButton = UIButton()
-        peopleButton.isEnabled = false
-        peopleButton.setImage(#imageLiteral(resourceName: "person"), for: .normal)
-        peopleButton.setTitle("\(numberOfPeople)", for: .normal)
-        peopleButton.titleLabel?.font = UIFont._16RegularFont
-        peopleButton.contentEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: 5)
-        peopleButton.imageEdgeInsets = UIEdgeInsets(top: 0, left: -5, bottom: 0, right: 5)
-        peopleButton.sizeToFit()
-        let peopleBarButton = UIBarButtonItem(customView: peopleButton)
-        
         if userRole == .admin {
             createPollButton = UIButton()
             createPollButton.setImage(#imageLiteral(resourceName: "whiteCreatePoll"), for: .normal)
             createPollButton.addTarget(self, action: #selector(createPollBtnPressed), for: .touchUpInside)
             let createPollBarButton = UIBarButtonItem(customView: createPollButton)
-            self.navigationItem.rightBarButtonItems = [createPollBarButton, peopleBarButton]
-        } else {
-            self.navigationItem.rightBarButtonItems = [peopleBarButton]
+            self.navigationItem.rightBarButtonItems = [createPollBarButton]
         }
     }
 

--- a/Clicker/ViewControllers/PollsViewController.swift
+++ b/Clicker/ViewControllers/PollsViewController.swift
@@ -43,7 +43,7 @@ class PollsViewController: UIViewController {
     let codeTextFieldEdgePadding: CGFloat = 18
     let codeTextFieldHeight: CGFloat = 40
     let codeTextFieldHorizontalPadding: CGFloat = 12
-    let codeTextFieldPlaceHolder = "Enter a code..."
+    let codeTextFieldPlaceHolder = "Enter a group code..."
     let createdPollsOptionsText = "Created"
     let editModalHeight: CGFloat = 205
     let errorText = "Error"

--- a/Clicker/ViewControllers/SettingsViewController.swift
+++ b/Clicker/ViewControllers/SettingsViewController.swift
@@ -16,7 +16,6 @@ class SettingsViewController: UIViewController {
     var adapter: ListAdapter!
     var collectionView: UICollectionView!
     var lineView: UIView!
-    var logOutButton: UIButton!
 
     // MARK: Data
     var data: [ListDiffable]!
@@ -27,6 +26,7 @@ class SettingsViewController: UIViewController {
     let account = "Account"
     let backButtonImageName = "darkexit"
     let feedbackDescription = "Let us know if you have any ideas, suggestions, or issues! Shake your phone to access the feedback form, or follow the link below."
+    let logOut = "Log Out"
     let more = "More"
     let moreApps = "More Apps"
     let navBarTitle = "Settings"
@@ -55,8 +55,9 @@ class SettingsViewController: UIViewController {
         let settingsDataModel5 = SettingsDataModel(state: .info, title: more, description: feedbackDescription)
         let settingsDataModel6 = SettingsDataModel(state: .link, title: sendUsFeedback, description: Links.feedbackForm)
         let settingsDataModel7 = SettingsDataModel(state: .link, title: privacyPolicy, description: Links.privacyPolicy)
+        let settingsDataModel8 = SettingsDataModel(state: .button, title: logOut, description: logOut)
         
-        data = [settingsModel1, separatorLineModel1, settingsModel2, settingsModel3, settingsModel4, separatorLineModel2, settingsDataModel5, settingsDataModel6, settingsDataModel7]
+        data = [settingsModel1, separatorLineModel1, settingsModel2, settingsModel3, settingsModel4, separatorLineModel2, settingsDataModel5, settingsDataModel6, settingsDataModel7, settingsDataModel8]
     }
 
     func setupNavBar() {
@@ -89,27 +90,10 @@ class SettingsViewController: UIViewController {
         adapter = ListAdapter(updater: ListAdapterUpdater(), viewController: self)
         adapter.collectionView = collectionView
         adapter.dataSource = self
-        
-        lineView = UIView()
-        lineView.backgroundColor = UIColor.clickerGrey5
-        view.addSubview(lineView)
-        
-        logOutButton = UIButton()
-        logOutButton.setTitle("Log Out", for: .normal)
-        logOutButton.titleLabel?.textAlignment = .center
-        logOutButton.titleLabel?.font = UIFont._18MediumFont
-        logOutButton.setTitleColor(.black, for: .normal)
-        logOutButton.addTarget(self, action: #selector(logOutAction), for: .touchUpInside)
-        view.addSubview(logOutButton)
+    
     }
     
     func setupConstraints() {
-        logOutButton.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.width.equalTo(150)
-            make.height.equalTo(22)
-            make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(20)
-        }
         
         collectionView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide.snp.top)
@@ -117,12 +101,6 @@ class SettingsViewController: UIViewController {
             make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(61)
         }
         
-        lineView.snp.makeConstraints { make in
-            make.height.equalTo(1)
-            make.width.equalToSuperview()
-            make.centerX.equalToSuperview()
-            make.top.equalTo(collectionView.snp.bottom)
-        }
     }
     
     func image(fromLayer layer: CALayer) -> UIImage {
@@ -178,7 +156,7 @@ extension SettingsViewController: ListAdapterDataSource {
     
     func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         if object is SettingsDataModel {
-            return SettingsSectionController()
+            return SettingsSectionController(delegate: self)
         } else {
             return SeparatorLineSectionController()
         }
@@ -186,6 +164,14 @@ extension SettingsViewController: ListAdapterDataSource {
     
     func emptyView(for listAdapter: ListAdapter) -> UIView? {
         return nil
+    }
+    
+}
+
+extension SettingsViewController: LogOutSectionControllerDelegate {
+    
+    func logOutSectionControllerButtonWasTapped() {
+        logOutAction()
     }
     
 }

--- a/Clicker/Views/Cards/CardCell.swift
+++ b/Clicker/Views/Cards/CardCell.swift
@@ -46,7 +46,7 @@ class CardCell: UICollectionViewCell {
     weak var delegate: CardCellDelegate!
     
     // MARK: - Constants
-    let collectionViewHorizontalPadding: CGFloat = 5.0
+    let collectionViewHorizontalPadding: CGFloat = 8.0
     let endPollText = "End Poll"
     let initialTimerLabelText = "00:00"
     let questionButtonBorderWidth: CGFloat = 1.0

--- a/Clicker/Views/Cards/EmptyStateCell.swift
+++ b/Clicker/Views/Cards/EmptyStateCell.swift
@@ -28,7 +28,7 @@ class EmptyStateCell: UICollectionViewCell {
     // MARK: - Constants
     let adminNothingToSeeText = "Nothing to see here."
     let adminWaitingText = "You haven’t made any polls yet!\nTap \"+\" above to try it out."
-    let cardControllerIconImageViewLength: CGFloat = 32.0
+    let cardControllerIconImageViewLength: CGFloat = 50.0
     let countLabelWidth: CGFloat = 42.0
     let createDraftButtonHeight: CGFloat = 47
     let createDraftButtonText = "Create a draft"
@@ -39,15 +39,16 @@ class EmptyStateCell: UICollectionViewCell {
     let draftsViewControllerIconImageViewLength: CGFloat = 50.0
     let draftsViewControllerIconImageViewTopPadding: CGFloat = 200.0
     let enterCodeText = "Enter a code below to join a group!"
-    let iconImageViewTopPadding: CGFloat = 142.0
+    let iconImageViewTopPadding: CGFloat = 176.0
     let joinedString = "joined"
     let manShruggingImageName = "man_shrugging"
     let monkeyEmojiImageName = "monkey_emoji"
     let noDraftsText = "No saved drafts!"
-    let pollsViewControllerIconImageViewLength: CGFloat = 45.0
-    let subtitleLabelTopPadding: CGFloat = 7.5
+    let pollsViewControllerIconImageViewTopPadding: CGFloat = 88.0
+    let pollsViewControllerIconImageViewLength: CGFloat = 50.0
+    let subtitleLabelTopPadding: CGFloat = 8.0
     let subtitleLabelWidth: CGFloat = 250.0
-    let titleLabelTopPadding: CGFloat = 18.5
+    let titleLabelTopPadding: CGFloat = 16.0
     let titleLabelWidth: CGFloat = 200.0
     let userNothingToSeeText = "Nothing to see yet."
     let userWaitingText = "Waiting for the host to post a poll..."
@@ -74,7 +75,7 @@ class EmptyStateCell: UICollectionViewCell {
         contentView.addSubview(iconImageView)
         
         titleLabel = UILabel()
-        titleLabel.font = ._16SemiboldFont
+        titleLabel.font = ._18SemiboldFont
         titleLabel.textAlignment = .center
         contentView.addSubview(titleLabel)
         
@@ -121,7 +122,7 @@ class EmptyStateCell: UICollectionViewCell {
             switch emptyStateModel.type {
             case .pollsViewController:
                 make.width.height.equalTo(pollsViewControllerIconImageViewLength)
-                make.top.equalToSuperview().offset(iconImageViewTopPadding)
+                make.top.equalToSuperview().offset(pollsViewControllerIconImageViewTopPadding)
             case .cardController:
                 make.width.height.equalTo(cardControllerIconImageViewLength)
                 make.top.equalToSuperview().offset(iconImageViewTopPadding)

--- a/Clicker/Views/Cards/MCResultCell.swift
+++ b/Clicker/Views/Cards/MCResultCell.swift
@@ -32,11 +32,11 @@ class MCResultCell: UICollectionViewCell {
     let checkImageViewLength: CGFloat = 14
     let containerViewBorderWidth: CGFloat = 0.5
     let containerViewCornerRadius: CGFloat = 6
-    let containerViewTopPadding: CGFloat = 5
+    let containerViewTopPadding: CGFloat = 8
     let labelFontSize: CGFloat = 13
-    let numSelectedLabelTrailingPadding: CGFloat = 14
+    let numSelectedLabelTrailingPadding: CGFloat = 16
     let numSelectedLabelWidth: CGFloat = 40
-    let optionLabelHorizontalPadding: CGFloat = 14
+    let optionLabelHorizontalPadding: CGFloat = 16
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Clicker/Views/Cards/PollMiscellaneousCell.swift
+++ b/Clicker/Views/Cards/PollMiscellaneousCell.swift
@@ -20,7 +20,7 @@ class PollMiscellaneousCell: UICollectionViewCell {
     
     // MARK: - Constants
     let descriptionLabelXPadding: CGFloat = 10
-    let endedTextMember = "Poll closed"
+    let endedTextMember = "Poll Closed"
     let iconImageViewLength: CGFloat = 15
     let labelFontSize: CGFloat = 12
     let liveEndedDescriptionTextAdmin = "Only you can see results"
@@ -30,7 +30,7 @@ class PollMiscellaneousCell: UICollectionViewCell {
     let sharedDescriptionText = "Shared with group"
     let sharedTextMember = "Final results  • "
     let totalVotesLabelTrailingPadding: CGFloat = 18
-    let voteString = "vote"
+    let voteString = "Vote"
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Clicker/Views/Cards/SeparatorLineCell.swift
+++ b/Clicker/Views/Cards/SeparatorLineCell.swift
@@ -18,7 +18,6 @@ class SeparatorLineCell: UICollectionViewCell {
     
     // MARK: - Constants
     let lineViewHeight: CGFloat = 1
-    let lineViewSettingsInset: CGFloat = 18
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -29,10 +28,8 @@ class SeparatorLineCell: UICollectionViewCell {
     }
     
     override func updateConstraints() {
-        let lineViewLeadingOffset = model.state == .settings ? lineViewSettingsInset : 0
         lineView.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(lineViewLeadingOffset)
-            make.bottom.trailing.equalToSuperview()
+            make.bottom.leading.trailing.equalToSuperview()  
             make.height.equalTo(lineViewHeight)
         }
         super.updateConstraints()

--- a/Clicker/Views/HomeScreen/Polls/PollPreviewCell.swift
+++ b/Clicker/Views/HomeScreen/Polls/PollPreviewCell.swift
@@ -40,18 +40,18 @@ class PollPreviewCell: UICollectionViewCell {
     weak var delegate: PollPreviewCellDelegate?
     
     // MARK: - Constants
-    let nameLabelTopPadding: CGFloat = 19.5
-    let nameLabelWidth: CGFloat = 300
-    let nameLabelLeftPadding: CGFloat = 17
-    let liveCircleViewLength: CGFloat = 7
-    let liveCircleViewTopPadding: CGFloat = 8.5
-    let liveLabelLeftPadding: CGFloat = 6
     let activityLabelTopPadding: CGFloat = 4
+    let dotsButtonLength: CGFloat = 40
+    let dotsButtonRightPadding: CGFloat = 18.0
+    let liveCircleViewLength: CGFloat = 7
+    let liveCircleViewTopPadding: CGFloat = 8.0
+    let liveLabelLeftPadding: CGFloat = 6.0
     let lineViewHeight: CGFloat = 1
     let lineViewLeftPadding: CGFloat = 18
-    let dotsButtonRightPadding: CGFloat = 12
-    let dotsButtonLength: CGFloat = 40
     let liveLabelText = "Live Now"
+    let nameLabelLeftPadding: CGFloat = 18.0
+    let nameLabelTopPadding: CGFloat = 20.0
+    let nameLabelWidth: CGFloat = 300
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Clicker/Views/Settings/SettingsLogOutButtonCell.swift
+++ b/Clicker/Views/Settings/SettingsLogOutButtonCell.swift
@@ -1,0 +1,63 @@
+//
+//  SettingsLogOutButtonCell.swift
+//  Clicker
+//
+//  Created by Lucy Xu on 3/23/19.
+//  Copyright © 2018 CornellAppDev. All rights reserved.
+//
+
+import UIKit
+
+protocol LogoutButtonCellDelegate: class {
+    func logOutButtonCellWasTapped()
+}
+
+class SettingsLogOutButtonCell: UICollectionViewCell {
+    
+    // MARK: Data vars
+    weak var delegate: LogoutButtonCellDelegate?
+    
+    // MARK: Views
+    var logOutButton: UIButton!
+    
+    // MARK: Layout constants
+    let logOutButtonOffset = 18
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupViews()
+        setupConstraints()
+    }
+    
+    func setupViews() {
+        logOutButton = UIButton()
+        logOutButton.setTitleColor(UIColor.clickerGreen0, for: .normal)
+        logOutButton.titleLabel?.textAlignment = .left
+        logOutButton.titleLabel?.font = UIFont._18MediumFont
+        logOutButton.contentHorizontalAlignment = .left
+        logOutButton.addTarget(self, action: #selector(logOutClicked), for: .touchUpInside)
+        contentView.addSubview(logOutButton)
+    }
+    
+    func setupConstraints() {
+        logOutButton.snp.makeConstraints { make in
+            make.left.equalToSuperview().offset(logOutButtonOffset)
+            make.right.centerY.equalToSuperview()
+        }
+    }
+    
+    func configureWith(settingsDataModel: SettingsDataModel) {
+        logOutButton.setTitle(settingsDataModel.title, for: .normal)
+    }
+    
+    // MARK: Actions
+    @objc func logOutClicked() {
+        delegate?.logOutButtonCellWasTapped()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}


### PR DESCRIPTION
Updated styling throughout the app to reflect new 8 pt styling. In particular, focused on the latest views added to Zeplin. They are named: 
- Poll Closed (Student Side)
- New Home Icons Copy
- New Home Icons Copy 11
- Empty Poll Copy 7
- Empty Poll Copy 16
- New Settings X

Most of the changes are padding fixes except for the new styling for the Settings page, which required me to make a new cell for the log out button to work with IGListKit:
- Old Styling: 
<img width="300" alt="Screen Shot 2019-03-24 at 8 11 49 AM" src="https://user-images.githubusercontent.com/29307883/54879374-a36f4d80-4e0e-11e9-98f9-b735acdab1b8.png">

- New Styling: 
<img width="300" alt="Screen Shot 2019-03-24 at 8 11 49 AM" src="https://user-images.githubusercontent.com/29307883/54879345-32c83100-4e0e-11e9-9e09-02af87dedbb7.png">
