### PR TITLE
Prompt user ratings every 10 launches

### DIFF
--- a/Clicker.xcodeproj/project.pbxproj
+++ b/Clicker.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 		D13E908B2086BC3200856DD4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C7F923CE1F73540600B1E975 /* LaunchScreen.storyboard */; };
 		D13E9092208712A300856DD4 /* PollBuilderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13E9091208712A300856DD4 /* PollBuilderViewController.swift */; };
 		D412ACD02246EDAA009B6E83 /* SettingsLogOutButtonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D412ACCF2246EDAA009B6E83 /* SettingsLogOutButtonCell.swift */; };
+		D412ACD22247BF7C009B6E83 /* Ratings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D412ACD12247BF7C009B6E83 /* Ratings.swift */; };
 		D946CA7E221346860005AD70 /* keys.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = D946CA7D221346860005AD70 /* keys.generated.swift */; };
 		D946CA822213D2EA0005AD70 /* testflight_release_notes.txt in Resources */ = {isa = PBXBuildFile; fileRef = D946CA812213D2EA0005AD70 /* testflight_release_notes.txt */; };
 /* End PBXBuildFile section */
@@ -325,6 +326,7 @@
 		C7F923D11F73540600B1E975 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D13E9091208712A300856DD4 /* PollBuilderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollBuilderViewController.swift; sourceTree = "<group>"; };
 		D412ACCF2246EDAA009B6E83 /* SettingsLogOutButtonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsLogOutButtonCell.swift; sourceTree = "<group>"; };
+		D412ACD12247BF7C009B6E83 /* Ratings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ratings.swift; sourceTree = "<group>"; };
 		D946CA7D221346860005AD70 /* keys.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = keys.generated.swift; sourceTree = "<group>"; };
 		D946CA812213D2EA0005AD70 /* testflight_release_notes.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = testflight_release_notes.txt; sourceTree = "<group>"; };
 		F8BCD96EC847A3A4C51959E6 /* Pods-Clicker.debug local server.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Clicker.debug local server.xcconfig"; path = "Pods/Target Support Files/Pods-Clicker/Pods-Clicker.debug local server.xcconfig"; sourceTree = "<group>"; };
@@ -665,6 +667,7 @@
 				C2E9C7082182A40600E36659 /* Analytics.swift */,
 				C2E9C70A2182ACCE00E36659 /* EventPayload.swift */,
 				C7F923CC1F73540600B1E975 /* Assets.xcassets */,
+				D412ACD12247BF7C009B6E83 /* Ratings.swift */,
 			);
 			path = Supporting;
 			sourceTree = "<group>";
@@ -1008,6 +1011,7 @@
 				63A4A6462094D41600523AE6 /* MCPollBuilderView.swift in Sources */,
 				B638A0AD2238B2E000D1C2D2 /* PollSettingsSectionController.swift in Sources */,
 				C72CD5281FAF6BF7004E68D9 /* UIColor+Shared.swift in Sources */,
+				D412ACD22247BF7C009B6E83 /* Ratings.swift in Sources */,
 				0CDAF0D521727DA3004DB6EA /* SpaceCell.swift in Sources */,
 				0C67D34E217BCD9B0000B2A1 /* NoResponsesCell.swift in Sources */,
 				C28679DD2155A5A300554F7B /* PollBuilderMCOptionModel.swift in Sources */,

--- a/Clicker/Models/User.swift
+++ b/Clicker/Models/User.swift
@@ -57,7 +57,6 @@ struct UserSession: Codable {
     let refreshToken: String
     let sessionExpiration: String
 
-    
     init(accessToken: String, refreshToken: String, sessionExpiration: String, isActive: Bool) {
         self.accessToken = accessToken
         self.isActive = isActive

--- a/Clicker/Models/User.swift
+++ b/Clicker/Models/User.swift
@@ -56,6 +56,7 @@ struct UserSession: Codable {
     let isActive: Bool
     let refreshToken: String
     let sessionExpiration: String
+
     
     init(accessToken: String, refreshToken: String, sessionExpiration: String, isActive: Bool) {
         self.accessToken = accessToken

--- a/Clicker/Supporting/Ratings.swift
+++ b/Clicker/Supporting/Ratings.swift
@@ -11,7 +11,7 @@ import StoreKit
 
 class Ratings {
     
-    static let launchThreshold = 10
+    static let launchThreshold = 1
     
     class func updateNumAppLaunches() {
         let numLaunches = getNumAppLaunches() + 1

--- a/Clicker/Supporting/Ratings.swift
+++ b/Clicker/Supporting/Ratings.swift
@@ -11,26 +11,28 @@ import StoreKit
 
 class Ratings {
     
-    static let launchThreshold = 20
-    static let NUMBER_OF_LAUNCHES = "NUMBER_OF_LAUNCHES"
+    static let shared = Ratings()
+    let launchThreshold = 20
+    let NUMBER_OF_LAUNCHES = "NUMBER_OF_LAUNCHES"
     
+    private init() {}
     
-    class func updateNumAppLaunches() {
+    func updateNumAppLaunches() {
         let numLaunches = getNumAppLaunches() + 1
         UserDefaults.standard.set(numLaunches, forKey: NUMBER_OF_LAUNCHES)
         UserDefaults.standard.synchronize()
     }
     
-    class func getNumAppLaunches() -> Int {
+    func getNumAppLaunches() -> Int {
         return UserDefaults.standard.value(forKey: NUMBER_OF_LAUNCHES) as? Int ?? 0
     }
     
-    class func shouldPromptReview() -> Bool {
+    func shouldPromptReview() -> Bool {
         let numLaunches = getNumAppLaunches()
         return numLaunches >= launchThreshold
     }
     
-    class func promptReview(){
+    func promptReview(){
         if #available(iOS 10.3, *)  {
             if shouldPromptReview() {
                 SKStoreReviewController.requestReview()
@@ -39,4 +41,5 @@ class Ratings {
             }
         }
     }
+    
 }

--- a/Clicker/Supporting/Ratings.swift
+++ b/Clicker/Supporting/Ratings.swift
@@ -11,11 +11,11 @@ import StoreKit
 
 class Ratings {
     
-    static let launchThreshold = 5
+    static let launchThreshold = 4
     
     class func updateNumAppLaunches() {
-        let runs = getNumAppLaunches() + 1
-        UserDefaults.standard.set(runs, forKey: "NUMBER_OF_LAUNCHES")
+        let numLaunches = getNumAppLaunches() + 1
+        UserDefaults.standard.set(numLaunches, forKey: "NUMBER_OF_LAUNCHES")
         UserDefaults.standard.synchronize()
     }
     
@@ -35,6 +35,8 @@ class Ratings {
         if #available(iOS 10.3, *)  {
             if shouldPromptReview() {
                 SKStoreReviewController.requestReview()
+                UserDefaults.standard.set(0, forKey: "NUMBER_OF_LAUNCHES")
+                UserDefaults.standard.synchronize()
             }
         }
     }

--- a/Clicker/Supporting/Ratings.swift
+++ b/Clicker/Supporting/Ratings.swift
@@ -11,7 +11,7 @@ import StoreKit
 
 class Ratings {
     
-    static let launchThreshold = 4
+    static let launchThreshold = 10
     
     class func updateNumAppLaunches() {
         let numLaunches = getNumAppLaunches() + 1

--- a/Clicker/Supporting/Ratings.swift
+++ b/Clicker/Supporting/Ratings.swift
@@ -32,7 +32,7 @@ class Ratings {
         return numLaunches >= launchThreshold
     }
     
-    func promptReview(){
+    func promptReview() {
         if #available(iOS 10.3, *)  {
             if shouldPromptReview() {
                 SKStoreReviewController.requestReview()

--- a/Clicker/Supporting/Ratings.swift
+++ b/Clicker/Supporting/Ratings.swift
@@ -1,0 +1,41 @@
+//
+//  Ratings.swift
+//  Clicker
+//
+//  Created by Lucy Xu on 3/24/19.
+//  Copyright © 2019 CornellAppDev. All rights reserved.
+//
+
+import Foundation
+import StoreKit
+
+class Ratings {
+    
+    static let launchThreshold = 5
+    
+    class func updateNumAppLaunches() {
+        let runs = getNumAppLaunches() + 1
+        UserDefaults.standard.set(runs, forKey: "NUMBER_OF_LAUNCHES")
+        UserDefaults.standard.synchronize()
+    }
+    
+    class func getNumAppLaunches() -> Int {
+        if let numLaunches = UserDefaults.standard.value(forKey: "NUMBER_OF_LAUNCHES") as? Int {
+            return numLaunches
+        }
+        return 0
+    }
+    
+    class func shouldPromptReview() -> Bool{
+        let numLaunches = getNumAppLaunches()
+        return numLaunches >= launchThreshold
+    }
+    
+    class func promptReview(){
+        if #available(iOS 10.3, *)  {
+            if shouldPromptReview() {
+                SKStoreReviewController.requestReview()
+            }
+        }
+    }
+}

--- a/Clicker/Supporting/Ratings.swift
+++ b/Clicker/Supporting/Ratings.swift
@@ -11,22 +11,21 @@ import StoreKit
 
 class Ratings {
     
-    static let launchThreshold = 1
+    static let launchThreshold = 20
+    static let NUMBER_OF_LAUNCHES = "NUMBER_OF_LAUNCHES"
+    
     
     class func updateNumAppLaunches() {
         let numLaunches = getNumAppLaunches() + 1
-        UserDefaults.standard.set(numLaunches, forKey: "NUMBER_OF_LAUNCHES")
+        UserDefaults.standard.set(numLaunches, forKey: NUMBER_OF_LAUNCHES)
         UserDefaults.standard.synchronize()
     }
     
     class func getNumAppLaunches() -> Int {
-        if let numLaunches = UserDefaults.standard.value(forKey: "NUMBER_OF_LAUNCHES") as? Int {
-            return numLaunches
-        }
-        return 0
+        return UserDefaults.standard.value(forKey: NUMBER_OF_LAUNCHES) as? Int ?? 0
     }
     
-    class func shouldPromptReview() -> Bool{
+    class func shouldPromptReview() -> Bool {
         let numLaunches = getNumAppLaunches()
         return numLaunches >= launchThreshold
     }
@@ -35,7 +34,7 @@ class Ratings {
         if #available(iOS 10.3, *)  {
             if shouldPromptReview() {
                 SKStoreReviewController.requestReview()
-                UserDefaults.standard.set(0, forKey: "NUMBER_OF_LAUNCHES")
+                UserDefaults.standard.set(0, forKey: NUMBER_OF_LAUNCHES)
                 UserDefaults.standard.synchronize()
             }
         }

--- a/Clicker/Supporting/Ratings.swift
+++ b/Clicker/Supporting/Ratings.swift
@@ -33,12 +33,10 @@ class Ratings {
     }
     
     func promptReview() {
-        if #available(iOS 10.3, *)  {
-            if shouldPromptReview() {
-                SKStoreReviewController.requestReview()
-                UserDefaults.standard.set(0, forKey: NUMBER_OF_LAUNCHES)
-                UserDefaults.standard.synchronize()
-            }
+        if #available(iOS 10.3, *), shouldPromptReview() {
+            SKStoreReviewController.requestReview()
+            UserDefaults.standard.set(0, forKey: NUMBER_OF_LAUNCHES)
+            UserDefaults.standard.synchronize()
         }
     }
     

--- a/Clicker/ViewControllers/PollsViewController.swift
+++ b/Clicker/ViewControllers/PollsViewController.swift
@@ -9,6 +9,7 @@
 import GoogleSignIn
 import IGListKit
 import Presentr
+import StoreKit
 import UIKit
 
 class PollsViewController: UIViewController {
@@ -72,6 +73,10 @@ class PollsViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        Ratings.updateNumAppLaunches()
+        Ratings.promptReview()
+        
         view.backgroundColor = .clickerGrey8
 
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
@@ -79,6 +84,7 @@ class PollsViewController: UIViewController {
         
         setupViews()
         setupConstraints()
+        
     }
     
     // MARK: - Configure

--- a/Clicker/ViewControllers/PollsViewController.swift
+++ b/Clicker/ViewControllers/PollsViewController.swift
@@ -74,14 +74,12 @@ class PollsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        Ratings.updateNumAppLaunches()
-        Ratings.promptReview()
-        
         view.backgroundColor = .clickerGrey8
 
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
         
+        promptUserReview()
         setupViews()
         setupConstraints()
         
@@ -281,6 +279,11 @@ class PollsViewController: UIViewController {
     
     func startSession(code: String, name: String, isGroup: Bool) -> Future<Response<Session>> {
         return networking(Endpoint.startSession(code: code, name: name, isGroup: isGroup)).decode()
+    }
+    
+    func promptUserReview() {
+        Ratings.updateNumAppLaunches()
+        Ratings.promptReview()
     }
     
     // MARK: - Actions

--- a/Clicker/ViewControllers/PollsViewController.swift
+++ b/Clicker/ViewControllers/PollsViewController.swift
@@ -281,8 +281,8 @@ class PollsViewController: UIViewController {
     }
     
     func promptUserReview() {
-        Ratings.updateNumAppLaunches()
-        Ratings.promptReview()
+        Ratings.shared.updateNumAppLaunches()
+        Ratings.shared.promptReview()
     }
     
     // MARK: - Actions

--- a/Clicker/ViewControllers/PollsViewController.swift
+++ b/Clicker/ViewControllers/PollsViewController.swift
@@ -82,7 +82,6 @@ class PollsViewController: UIViewController {
         promptUserReview()
         setupViews()
         setupConstraints()
-        
     }
     
     // MARK: - Configure


### PR DESCRIPTION
Prompt users for ratings every ten launches of app. 

Files added: 
- Ratings.swift: Compartmentalize code for prompting user ratings. Every time a user launches Pollo, increment "NUMBER_OF_LAUNCHES" by 1 and prompt for rating after 10 launches. Reset "NUMBER_OF_LAUNCHES" to 0 after prompt. 

Question: Where should "Ratings.swift" go?

Screenshot:
<img width="522" alt="Screen Shot 2019-03-24 at 3 32 36 PM" src="https://user-images.githubusercontent.com/29307883/54884656-0f22dc00-4e4a-11e9-828c-720f4754f3c1.png">


