### PR TITLE
Fix group controls unique model bug

### DIFF
--- a/Clicker/ViewControllers/GroupControlsViewController.swift
+++ b/Clicker/ViewControllers/GroupControlsViewController.swift
@@ -37,6 +37,8 @@ class GroupControlsViewController: UIViewController {
     var spaceOne: SpaceModel!
     var spaceTwo: SpaceModel!
     var spaceThree: SpaceModel!
+    var spaceFour: SpaceModel!
+    var spaceFive: SpaceModel!
 
     // MARK: - Constants
     let attendanceHeaderLabel = "Attendance"
@@ -58,10 +60,12 @@ class GroupControlsViewController: UIViewController {
     let navigationTitle = "Group Controls"
     let pollSettingsHeaderLabel = "Poll Settings"
     let separatorLineViewWidth: CGFloat = 0.5
+    let spaceFiveHeight: CGFloat = 16
+    let spaceFourHeight: CGFloat = 57
     let spaceOneHeight: CGFloat = 38
+    let spaceThreeHeight: CGFloat = 16
     let spaceTwoHeight: CGFloat = 16
-    let spaceThreeHeight: CGFloat = 57
-    
+
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return .lightContent
     }
@@ -80,6 +84,8 @@ class GroupControlsViewController: UIViewController {
         spaceOne = SpaceModel(space: spaceOneHeight, backgroundColor: .clickerBlack1)
         spaceTwo = SpaceModel(space: spaceTwoHeight, backgroundColor: .clickerBlack1)
         spaceThree = SpaceModel(space: spaceThreeHeight, backgroundColor: .clickerBlack1)
+        spaceFour = SpaceModel(space: spaceFourHeight, backgroundColor: .clickerBlack1)
+        spaceFive = SpaceModel(space: spaceFiveHeight, backgroundColor: .clickerBlack1)
 
         setupNavBar()
         setupViews()
@@ -166,11 +172,11 @@ extension GroupControlsViewController: ListAdapterDataSource {
         
         if pollsDateAttendanceArray.count <= 3 {
             let precursorArray: [ListDiffable] = [infoModel, spaceOne, attendanceHeader, spaceTwo]
-            let postArray: [ListDiffable] = [exportAttendanceModel, spaceThree, pollSettingsHeader, liveQuestionsSetting, filterSetting, locationSetting, spaceTwo]
+            let postArray: [ListDiffable] = [exportAttendanceModel, spaceThree, pollSettingsHeader, liveQuestionsSetting, filterSetting, locationSetting, spaceFive]
             return [precursorArray, pollsDateAttendanceArray, postArray].flatMap {$0}
         }
         let viewAllModel = ViewAllModel()
-        return [infoModel, spaceOne, attendanceHeader, spaceTwo, pollsDateAttendanceArray[0], pollsDateAttendanceArray[1], pollsDateAttendanceArray[2], spaceTwo, viewAllModel, exportAttendanceModel, spaceThree, pollSettingsHeader, liveQuestionsSetting, filterSetting, locationSetting, spaceTwo]
+        return [infoModel, spaceOne, attendanceHeader, spaceTwo, pollsDateAttendanceArray[0], pollsDateAttendanceArray[1], pollsDateAttendanceArray[2], spaceThree, viewAllModel, exportAttendanceModel, spaceFour, pollSettingsHeader, liveQuestionsSetting, filterSetting, locationSetting, spaceFive]
     }
 
     func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {


### PR DESCRIPTION
- Fix IGListKit error thrown when multiple models used in list adapter
- Basically, `spaceTwo` was being used multiple times which is a no-no for IGListKit