### PR TITLE
Socket error handling

### DIFF
--- a/Clicker/Extensions/UIViewController+Shared.swift
+++ b/Clicker/Extensions/UIViewController+Shared.swift
@@ -11,9 +11,9 @@ import SwiftyJSON
 
 extension UIViewController {
 
-    func createAlert(title: String, message: String) -> UIAlertController {
-        let alertController = UIAlertController(title: title, message: message, preferredStyle: UIAlertControllerStyle.alert)
-        alertController.addAction(UIAlertAction(title: "Close", style: .cancel, handler: nil))
+    func createAlert(title: String, message: String, handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertController {
+        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alertController.addAction(UIAlertAction(title: "Close", style: .cancel, handler: handler))
         return alertController
     }
 

--- a/Clicker/Models/Socket.swift
+++ b/Clicker/Models/Socket.swift
@@ -39,6 +39,10 @@ class Socket {
         socket.on(clientEvent: .disconnect) { _, _ in
             self.delegate?.sessionDisconnected()
         }
+
+        socket.on(clientEvent: .error) { _, _ in
+            self.delegate?.sessionErrored()
+        }
         
         socket.on(Routes.userStart) { data, _ in
             guard let json = data[0] as? [String: Any], let pollDict = json[ParserKeys.pollKey] as? [String: Any] else {

--- a/Clicker/Models/SocketDelegate.swift
+++ b/Clicker/Models/SocketDelegate.swift
@@ -14,6 +14,7 @@ protocol SocketDelegate: class {
     func receivedUserCount(_ count: Int)
     func sessionConnected()
     func sessionDisconnected()
+    func sessionErrored()
     
     // USER RECEIVES
     func receivedResults(_ currentState: CurrentState)

--- a/Clicker/Models/User.swift
+++ b/Clicker/Models/User.swift
@@ -55,9 +55,9 @@ struct UserSession: Codable {
     let accessToken: String
     let isActive: Bool
     let refreshToken: String
-    let sessionExpiration: String
-
-    init(accessToken: String, refreshToken: String, sessionExpiration: String, isActive: Bool) {
+    let sessionExpiration: Int
+    
+    init(accessToken: String, refreshToken: String, sessionExpiration: Int, isActive: Bool) {
         self.accessToken = accessToken
         self.isActive = isActive
         self.refreshToken = refreshToken

--- a/Clicker/ViewControllers/PollsDateViewController+Extension.swift
+++ b/Clicker/ViewControllers/PollsDateViewController+Extension.swift
@@ -158,6 +158,19 @@ extension PollsDateViewController: SocketDelegate {
     func sessionConnected() {}
     
     func sessionDisconnected() {}
+
+    func sessionErrored() {
+        socket.socket.connect(timeoutAfter: 5) { [weak self] in
+            guard let `self` = self else { return }
+            let alertController = self.createAlert(title: "Error", message: "Could not join poll. Try joining again!", handler: { _ in
+                self.goBack()
+                self.socket.delegate = nil
+            })
+            if self.presentedViewController == nil {
+                self.present(alertController, animated: true, completion: nil)
+            }
+        }
+    }
     
     func receivedUserCount(_ count: Int) {
         numberOfPeople = count


### PR DESCRIPTION
- Sockets disconnect after some time of idle activity/network change, but the app still seems "usable" so this error handling should prompt the user to try and re-join the poll again
- Attempt to reconnect upon receiving socket error, if after 5 seconds there's no luck, the alert controller will present and dismiss back to `PollsViewController`

Screenshot:
![image](https://user-images.githubusercontent.com/20246620/55036651-ab3b1780-4ff1-11e9-94fd-06b443938895.png)
