### PR TITLE
Lucy/dots touch

### DIFF
--- a/Clicker/Views/Cards/NavigationTitleView.swift
+++ b/Clicker/Views/Cards/NavigationTitleView.swift
@@ -29,6 +29,8 @@ class NavigationTitleView: UIView {
     let arrowImageViewLeftPadding: CGFloat = 6
     let arrowImageViewWidth: CGFloat = 5.3
     let labelInset: CGFloat = 10
+    let navigationButtonVerticalEdgeInset: CGFloat = 10
+    let navigationButtonHorizontalEdgeInset: CGFloat = 30
     let primaryLabelHeight: CGFloat = 19
     let primaryLabelWidth = UIScreen.main.bounds.width * 0.5
     let secondaryLabelHeight: CGFloat = 15
@@ -64,6 +66,7 @@ class NavigationTitleView: UIView {
 
         navigationButton = UIButton()
         navigationButton.backgroundColor = .clear
+        navigationButton.contentEdgeInsets = UIEdgeInsets(top: navigationButtonVerticalEdgeInset, left: navigationButtonHorizontalEdgeInset, bottom: navigationButtonVerticalEdgeInset, right: navigationButtonHorizontalEdgeInset)
         navigationButton.addTarget(self, action: #selector(groupControlsBtnTapped), for: .touchUpInside)
         addSubview(navigationButton)
     }

--- a/Clicker/Views/Drafts/DraftCell.swift
+++ b/Clicker/Views/Drafts/DraftCell.swift
@@ -143,7 +143,7 @@ class DraftCell: UICollectionViewCell {
         
         editButton.snp.makeConstraints { make in
             make.width.height.equalTo(editButtonWidth)
-            make.centerY.equalToSuperview()
+            make.centerY.equalTo(editImageView.snp.centerY)
             make.trailing.equalTo(borderView.snp.trailing).inset(horizontalPadding)
         }
         


### PR DESCRIPTION
Enlarge tappable area of ellipsis dots in delete drafts and group controls button. 

New button sizes displayed in following screenshots:

1. Delete drafts:
<img width="300" alt="Screen Shot 2019-04-10 at 9 46 37 AM" src="https://user-images.githubusercontent.com/29307883/55914614-96e04880-5bb5-11e9-95cd-e3b8bc61f714.png">

2. Group Controls
<img width="300" alt="Screen Shot 2019-04-10 at 9 46 49 AM" src="https://user-images.githubusercontent.com/29307883/55914620-9b0c6600-5bb5-11e9-84ec-01f96ec2cb38.png">




