### PR TITLE
Lucy/resize-question-char-count

### DIFF
--- a/Clicker/SectionControllers/Drafts/DraftSectionController.swift
+++ b/Clicker/SectionControllers/Drafts/DraftSectionController.swift
@@ -23,6 +23,7 @@ class DraftSectionController: ListSectionController, DraftCellDelegate {
     // MARK: - Constants
     let constrainedTextWidth: CGFloat = 253
     let interitemSpacing: CGFloat = 18
+    let maxDraftTextHeight: CGFloat = 130
     
     init(delegate: DraftSectionControllerDelegate) {
         super.init()
@@ -35,8 +36,10 @@ class DraftSectionController: ListSectionController, DraftCellDelegate {
         guard let containerSize = collectionContext?.containerSize else {
             return .zero
         }
-        let textHeight = draft.text.height(withConstrainedWidth: constrainedTextWidth, font: ._18HeavyFont)
-        return CGSize(width: containerSize.width, height: textHeight + 65)
+        let calculatedTextHeight = draft.text.height(withConstrainedWidth: constrainedTextWidth, font: ._18HeavyFont)
+        let adjustedTextHeight = calculatedTextHeight + 65 // 65 being the total padding + questionType height
+        let textHeight = (adjustedTextHeight > maxDraftTextHeight) ? maxDraftTextHeight : adjustedTextHeight
+        return CGSize(width: containerSize.width, height: textHeight)
     }
     
     override func cellForItem(at index: Int) -> UICollectionViewCell {

--- a/Clicker/SectionControllers/PollOptionsCellSectionControllers/AskQuestionSectionController.swift
+++ b/Clicker/SectionControllers/PollOptionsCellSectionControllers/AskQuestionSectionController.swift
@@ -11,6 +11,7 @@ import IGListKit
 protocol AskQuestionSectionControllerDelegate: class {
     func askQuestionSectionControllerDidUpdateEditable(_ editable: Bool)
     func askQuestionSectionControllerDidUpdateText(_ text: String?)
+    func askQuestionSectionControllerDidUpdateHeight()
 }
 
 class AskQuestionSectionController: ListSectionController {
@@ -20,7 +21,8 @@ class AskQuestionSectionController: ListSectionController {
     weak var delegate: AskQuestionSectionControllerDelegate?
 
     // MARK: - Constants
-    let cellHeight: CGFloat = 48
+    let cellPadding: CGFloat = 10
+    var cellHeight: CGFloat = 48
 
     // MARK: - Init
     init(delegate: AskQuestionSectionControllerDelegate) {
@@ -50,7 +52,7 @@ class AskQuestionSectionController: ListSectionController {
         guard let cell = collectionContext?.cellForItem(at: 0, sectionController: self) as? AskQuestionCell else {
             return nil
         }
-        return cell.textField.text
+        return cell.questionTextView.text
     }
 
 }
@@ -63,6 +65,11 @@ extension AskQuestionSectionController: AskQuestionCellDelegate {
 
     func askQuestionCellDidUpdateText(_ text: String?) {
         delegate?.askQuestionSectionControllerDidUpdateText(text)
+    }
+    
+    func askQuestionCellDidUpdateHeight(_ height: CGFloat) {
+        cellHeight = height + cellPadding
+        delegate?.askQuestionSectionControllerDidUpdateHeight()
     }
 
 }

--- a/Clicker/Supporting/Constants.swift
+++ b/Clicker/Supporting/Constants.swift
@@ -113,7 +113,7 @@ struct IntegerConstants {
     static let maxOptionsForAdminMC = 6
     static let maxOptionsForMemberFR = 6
     static let maxOptionsForMemberMC = 8
-    static let maxQuestionCharacterCount = 58
+    static let maxQuestionCharacterCount = 120
 }
 
 struct UserDefault {

--- a/Clicker/Views/Drafts/DraftCell.swift
+++ b/Clicker/Views/Drafts/DraftCell.swift
@@ -36,6 +36,7 @@ class DraftCell: UICollectionViewCell {
     let freeResponse = "Free Response"
     let horizontalPadding: CGFloat = 18
     let multipleChoice = "Multiple Choice"
+    let questionLabelMaxNumLines = 3
     let questionLabelVerticalPadding: CGFloat = 20
     let zoomDuration: TimeInterval = 0.25
     let zoomInScale: CGFloat = 0.98
@@ -77,7 +78,7 @@ class DraftCell: UICollectionViewCell {
         questionLabel.textAlignment = .left
         questionLabel.backgroundColor = .clear
         questionLabel.textColor = .clickerGrey2
-        questionLabel.numberOfLines = 2
+        questionLabel.numberOfLines = questionLabelMaxNumLines
         questionLabel.lineBreakMode = .byTruncatingTail
         contentView.addSubview(questionLabel)
         

--- a/Clicker/Views/PollBuilder/FRPollBuilderView+Extension.swift
+++ b/Clicker/Views/PollBuilder/FRPollBuilderView+Extension.swift
@@ -62,6 +62,10 @@ extension FRPollBuilderView: AskQuestionSectionControllerDelegate {
     func askQuestionSectionControllerDidUpdateText(_ text: String?) {
         askQuestionModel.currentQuestion = text
     }
+    
+    func askQuestionSectionControllerDidUpdateHeight() {
+        adapter.performUpdates(animated: false, completion: nil)
+    }
 
 }
 

--- a/Clicker/Views/PollBuilder/MCPollBuilderView+Extension.swift
+++ b/Clicker/Views/PollBuilder/MCPollBuilderView+Extension.swift
@@ -146,6 +146,10 @@ extension MCPollBuilderView: AskQuestionSectionControllerDelegate {
     func askQuestionSectionControllerDidUpdateText(_ text: String?) {
         askQuestionModel.currentQuestion = text
     }
+    
+    func askQuestionSectionControllerDidUpdateHeight() {
+        adapter.performUpdates(animated: false, completion: nil)
+    }
 
 }
 


### PR DESCRIPTION
**What I did**
- Adjusted question text field to be multiline and dynamic height
- Added character count to text field
- Increased maximum characters to 120, which fills up two and a half lines
- Updated cell height of drafts and increased line display to 3 lines max

**Some questions I have**
- Any thoughts about the styling of the character count? Should I add more padding? Change the font and color?
- Any thoughts about the height of the draft? I wrote it based off of what was previously written so I could be wrong with my padding calculations.
- Anything I can change in terms of my implementation? There are some places where code seems duplicated but I think it may be necessary?

**Some screenshots of the new look:**
<img width="300" alt="Screen Shot 2019-04-21 at 7 53 35 PM" src="https://user-images.githubusercontent.com/29307883/56477079-a2fabe80-646f-11e9-954e-9816f42b7384.png">
<img width="300" alt="Screen Shot 2019-04-21 at 7 53 31 PM" src="https://user-images.githubusercontent.com/29307883/56477080-a2fabe80-646f-11e9-9892-82717d27c766.png">