### PR TITLE
Implement press enter to join poll and incorrect code handling

### DIFF
--- a/Clicker/Supporting/Constants.swift
+++ b/Clicker/Supporting/Constants.swift
@@ -124,6 +124,7 @@ struct IntegerConstants {
     static let maxOptionsForMemberFR = 6
     static let maxOptionsForMemberMC = 8
     static let maxQuestionCharacterCount = 120
+    static let validCodeLength = 6
 }
 
 struct UserDefault {

--- a/Clicker/ViewControllers/PollsViewController+Extension.swift
+++ b/Clicker/ViewControllers/PollsViewController+Extension.swift
@@ -57,7 +57,7 @@ extension PollsViewController: PollsCellDelegate {
         isOpeningGroup = true
         joinSessionWithIdAndCode(id: session.id, code: session.code).chained { sessionResponse -> Future<Response<[PollsDateModel]>> in
             let session = sessionResponse.data
-            return self.getSortedPolls(with: session.id)
+            return self.getSortedPolls(with: session.id).decode()
         }.observe { [weak self] result in
             guard let `self` = self else { return }
             DispatchQueue.main.async {
@@ -162,7 +162,10 @@ extension PollsViewController: SliderBarDelegate {
 extension PollsViewController: UITextFieldDelegate {
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        self.view.endEditing(true)
+        if let text = textField.text, text.count == IntegerConstants.validCodeLength { // Valid code length
+            joinSession()
+        }
+        view.endEditing(true)
         return false
     }
     


### PR DESCRIPTION
- Pressing "enter" on the keyboard allows you to join a poll (if 6 characters are entered)
- Fixes error with decoding so that error case w/incorrect poll code is now handled