### PR TITLE
Filter FR profanity

### DIFF
--- a/Clicker/Extensions/UITextField+Shared.swift
+++ b/Clicker/Extensions/UITextField+Shared.swift
@@ -10,13 +10,12 @@ import Foundation
 
 extension UITextField {
 
-    func updateTextToDisplayProfanity(for words: [String]) {
-        guard let text = self.text else { return }
+    func updateTextToDisplayProfanity(for words: [String], in text: String) {
         let nsString = text as NSString
         let attributedString = NSMutableAttributedString(string: text)
         words.forEach {
             let range = nsString.range(of: $0)
-            attributedString.addAttribute(.foregroundColor, value: UIColor.red, range: range)
+            attributedString.addAttribute(.foregroundColor, value: UIColor.clickerRed, range: range)
         }
         attributedText = attributedString
     }

--- a/Clicker/Models/ListDiffableModels/FRInputModel.swift
+++ b/Clicker/Models/ListDiffableModels/FRInputModel.swift
@@ -10,7 +10,15 @@ import IGListKit
 
 class FRInputModel: ListDiffable {
 
+    var filter: [String]?
+    var text: String?
+
     let identifier = UUID().uuidString
+
+    init(pollFilter: PollFilter? = nil) {
+        self.filter = pollFilter?.filter
+        self.text = pollFilter?.text
+    }
 
     func diffIdentifier() -> NSObjectProtocol {
         return identifier as NSString

--- a/Clicker/Models/ListDiffableModels/Poll.swift
+++ b/Clicker/Models/ListDiffableModels/Poll.swift
@@ -81,6 +81,7 @@ class Poll: Codable {
     var correctAnswer: String?  // only exists for multiple choice (format: 'A', 'B', ...)
     var createdAt: String? // string of seconds since 1970
     var id: Int?
+    var pollFilter: PollFilter? // used for filtering user profanity
     var state: PollState
     var text: String
     var type: QuestionType

--- a/Clicker/SectionControllers/CardSectionControllers/FRInputSectionController.swift
+++ b/Clicker/SectionControllers/CardSectionControllers/FRInputSectionController.swift
@@ -34,7 +34,7 @@ class FRInputSectionController: ListSectionController {
     
     override func cellForItem(at index: Int) -> UICollectionViewCell {
         let cell = collectionContext?.dequeueReusableCell(of: FRInputCell.self, for: self, at: index) as! FRInputCell
-        cell.configure(with: self)
+        cell.configure(for: frInputModel, with: self)
         cell.setNeedsUpdateConstraints()
         return cell
     }

--- a/Clicker/ViewControllers/CardController+Extension.swift
+++ b/Clicker/ViewControllers/CardController+Extension.swift
@@ -345,7 +345,15 @@ extension CardController: SocketDelegate {
         }
     }
 
-    func receivedFRFilter(_ pollFilter: PollFilter) { }
+    func receivedFRFilter(_ pollFilter: PollFilter) {
+        guard !pollFilter.success else { return }
+        let newPoll = Poll(poll: pollsDateModel.polls[currentIndex], state: pollsDateModel.polls[currentIndex].state)
+        newPoll.pollFilter = pollFilter
+        updateLatestPoll(with: newPoll)
+        adapter.performUpdates(animated: false, completion: nil)
+        let alertController = self.createAlert(title: "Inappropriate Content", message: "We have detected inappropriate language. Please submit an appropriate response.")
+        present(alertController, animated: true, completion: nil)
+    }
 
     func updatedTally(_ poll: Poll, userRole: UserRole) {
         if !pollsDateModel.dateValue.isSameDay(as: Date()) {

--- a/Clicker/ViewControllers/GroupControlsViewController.swift
+++ b/Clicker/ViewControllers/GroupControlsViewController.swift
@@ -6,9 +6,10 @@
 //  Copyright © 2018 CornellAppDev. All rights reserved.
 //
 
-import UIKit
+import FutureNova
 import IGListKit
 import SnapKit
+import UIKit
 
 protocol GroupControlsViewControllerDelegate: class {
     func groupControlsViewControllerDidUpdateSession(_ session: Session)

--- a/Clicker/ViewControllers/PollsDateViewController+Extension.swift
+++ b/Clicker/ViewControllers/PollsDateViewController+Extension.swift
@@ -161,6 +161,8 @@ extension PollsDateViewController: SocketDelegate {
     
     func sessionDisconnected() {}
 
+    func receivedFRFilter(_ pollFilter: PollFilter) { }
+
     func sessionErrored() {
         socket.socket.connect(timeoutAfter: 5) { [weak self] in
             guard let `self` = self else { return }
@@ -233,8 +235,6 @@ extension PollsDateViewController: SocketDelegate {
         updateLatestPoll(with: poll)
         adapter.performUpdates(animated: false, completion: nil)
     }
-
-    func receivedFRFilter(_ pollFilter: PollFilter) { }
 
     func updatedTally(_ poll: Poll, userRole: UserRole) {
         updateLatestPoll(with: poll)

--- a/Clicker/Views/Cards/CardCell.swift
+++ b/Clicker/Views/Cards/CardCell.swift
@@ -142,6 +142,7 @@ class CardCell: UICollectionViewCell {
         pollOptionsModel = buildPollOptionsModel(from: poll, userRole: userRole)
         let didSubmitChoice = userRole == .admin ? false : poll.getSelected() != nil
         miscellaneousModel = PollMiscellaneousModel(questionType: poll.type, pollState: poll.state, totalVotes: poll.getTotalResults(for: userRole), userRole: userRole, didSubmitChoice: didSubmitChoice)
+        frInputModel = FRInputModel(pollFilter: poll.pollFilter)
         adapter.performUpdates(animated: false, completion: nil)
     }
 

--- a/Clicker/Views/Cards/FRInputCell.swift
+++ b/Clicker/Views/Cards/FRInputCell.swift
@@ -64,8 +64,10 @@ class FRInputCell: UICollectionViewCell {
     }
     
     // MARK: - Configure
-    func configure(with delegate: FRInputCellDelegate) {
+    func configure(for model: FRInputModel, with delegate: FRInputCellDelegate) {
         self.delegate = delegate
+        guard let filter = model.filter, let text = model.text else { return }
+        inputTextField.updateTextToDisplayProfanity(for: filter, in: text)
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -80,7 +82,6 @@ extension FRInputCell: UITextFieldDelegate {
         if let text = textField.text, !text.isEmpty {
             delegate?.frInputCellSubmittedResponse(response: text)
             textField.text = ""
-            // TODO: fix this to only clear if response succeeds, else color words
         }
         endEditing(true)
         return false


### PR DESCRIPTION
Another one (the last one?)
- Finish FR filtering for profanity
- Display visual prompt for bad language detected in socket
- Update `Poll` and `FRInputModel` accordingly to reflect filtering input

Screenshot:
<img width="368" alt="image" src="https://user-images.githubusercontent.com/20246620/56937806-b1c71e00-6acc-11e9-8e41-9963d184e272.png">
