### PR TITLE
Fix UITextField bug in CreateMCOptionCell

### DIFF
--- a/Pollo.xcodeproj/project.pbxproj
+++ b/Pollo.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		0C40B47B22063DDD005BED7B /* DraftEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C40B47A22063DDD005BED7B /* DraftEndpoints.swift */; };
 		0C40B47D22064263005BED7B /* SessionEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C40B47C22064263005BED7B /* SessionEndpoints.swift */; };
 		0C4A24CF227638A700AE0B76 /* UITextField+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C4A24CE227638A700AE0B76 /* UITextField+Shared.swift */; };
+		0C50DFBC234050E3001AFC56 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0C50DFBB234050E3001AFC56 /* GoogleService-Info.plist */; };
 		0C531994215E7C1F00E4EFB7 /* CustomModalPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C531993215E7C1F00E4EFB7 /* CustomModalPresentationController.swift */; };
 		0C55CE262233056900E9912C /* HeaderModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C55CE252233056900E9912C /* HeaderModel.swift */; };
 		0C5C5F92220F9FDA0080F0AA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C7F923CC1F73540600B1E975 /* Assets.xcassets */; };
@@ -27,16 +28,12 @@
 		0CDAF0D321727D4B004DB6EA /* SpaceSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDAF0D221727D4B004DB6EA /* SpaceSectionController.swift */; };
 		0CDAF0D521727DA3004DB6EA /* SpaceCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDAF0D421727DA3004DB6EA /* SpaceCell.swift */; };
 		0CF647832176970900535573 /* ArrowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF647822176970900535573 /* ArrowView.swift */; };
-		20FDA08B232BF481006082B8 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 20FDA08A232BF481006082B8 /* GoogleService-Info.plist */; };
 		3BE2EC4CF6A43F972650EC5C /* Pods_Pollo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8812616CD823A168F697E7F4 /* Pods_Pollo.framework */; };
-		6321B786209D42A800B3A934 /* FROptionsDropDownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6321B785209D42A800B3A934 /* FROptionsDropDownView.swift */; };
 		6353FD3A2086DDC900E16EB2 /* CardController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6353FD392086DDC900E16EB2 /* CardController.swift */; };
-		636B0F15209D2DDA00769E14 /* QuestionTypeDropDownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B0F14209D2DDA00769E14 /* QuestionTypeDropDownView.swift */; };
 		637FD6932093E5FA007BADF1 /* NameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637FD6922093E5FA007BADF1 /* NameView.swift */; };
 		6389C94E20858D5400F78003 /* PollPreviewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6389C94D20858D5400F78003 /* PollPreviewCell.swift */; };
 		6389C9522085953F00F78003 /* PollsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6389C9512085953F00F78003 /* PollsCell.swift */; };
 		6397F8C82174294C00F515DE /* UINavigationController+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6397F8C72174294C00F515DE /* UINavigationController+Shared.swift */; };
-		639B4D562093F975009D3309 /* PickQTypeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639B4D552093F975009D3309 /* PickQTypeViewController.swift */; };
 		63A4A6462094D41600523AE6 /* MCPollBuilderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A4A6452094D41600523AE6 /* MCPollBuilderView.swift */; };
 		63A4A6482094D5EF00523AE6 /* FRPollBuilderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A4A6472094D5EF00523AE6 /* FRPollBuilderView.swift */; };
 		63A4A64E2094FD7800523AE6 /* DraftCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A4A64D2094FD7800523AE6 /* DraftCell.swift */; };
@@ -55,7 +52,6 @@
 		B638A0A9223833B800D1C2D2 /* PollsSettingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B638A0A8223833B800D1C2D2 /* PollsSettingModel.swift */; };
 		B638A0AB22389FB300D1C2D2 /* SettingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B638A0AA22389FB300D1C2D2 /* SettingCell.swift */; };
 		B638A0AD2238B2E000D1C2D2 /* PollSettingsSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B638A0AC2238B2E000D1C2D2 /* PollSettingsSectionController.swift */; };
-		B6A23E73232E9F7A0086CC1C /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = B6A23E72232E9F7A0086CC1C /* GoogleService-Info.plist */; };
 		C203E56221332FA30016A147 /* PollsViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C203E56121332FA30016A147 /* PollsViewController+Extension.swift */; };
 		C20B570721388F500091034F /* EmptyStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20B570621388F500091034F /* EmptyStateModel.swift */; };
 		C20B57092138903B0091034F /* EmptyStateSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20B57082138903B0091034F /* EmptyStateSectionController.swift */; };
@@ -71,9 +67,6 @@
 		C212179F20281E94007395DA /* UIFont+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = C212179E20281E94007395DA /* UIFont+Shared.swift */; };
 		C212EE2D21838D9600D15785 /* QuizModeOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C212EE2C21838D9600D15785 /* QuizModeOverlayView.swift */; };
 		C21C95BA2145D42F00F58874 /* OptionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21C95B92145D42F00F58874 /* OptionModel.swift */; };
-		C21C95BC2145D57000F58874 /* FROptionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21C95BB2145D57000F58874 /* FROptionModel.swift */; };
-		C21C95BE2145D90900F58874 /* FROptionSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21C95BD2145D90900F58874 /* FROptionSectionController.swift */; };
-		C21C95C02145DB5400F58874 /* FROptionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21C95BF2145DB5400F58874 /* FROptionCell.swift */; };
 		C21D98812083D32000191103 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21D98802083D32000191103 /* LoginViewController.swift */; };
 		C22D5B5A21432411005A0E29 /* MCChoiceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22D5B5921432411005A0E29 /* MCChoiceModel.swift */; };
 		C22D5B5C21432562005A0E29 /* MCChoiceSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22D5B5B21432562005A0E29 /* MCChoiceSectionController.swift */; };
@@ -120,9 +113,6 @@
 		C28D0B2F21712C3900FCDE0A /* ActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C28D0B2E21712C3900FCDE0A /* ActivityIndicatorView.swift */; };
 		C28FE95D21571E4B001AC6AB /* PollBuilderViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C28FE95C21571E4B001AC6AB /* PollBuilderViewController+Extension.swift */; };
 		C2900D432146F72900566F25 /* String+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2900D422146F72900566F25 /* String+Shared.swift */; };
-		C2900D45214703E700566F25 /* FRInputModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2900D44214703E700566F25 /* FRInputModel.swift */; };
-		C2900D472147043E00566F25 /* FRInputSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2900D462147043E00566F25 /* FRInputSectionController.swift */; };
-		C2900D49214706C300566F25 /* FRInputCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2900D48214706C300566F25 /* FRInputCell.swift */; };
 		C2A0F7C92139F5E100A28D75 /* PollMiscellaneousSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A0F7C82139F5E100A28D75 /* PollMiscellaneousSectionController.swift */; };
 		C2A0F7CB213A0BC200A28D75 /* PollMiscellaneousCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A0F7CA213A0BC200A28D75 /* PollMiscellaneousCell.swift */; };
 		C2A0F7CD213A106C00A28D75 /* HamburgerCardModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A0F7CC213A106C00A28D75 /* HamburgerCardModel.swift */; };
@@ -130,7 +120,6 @@
 		C2A0F7D1213A11CE00A28D75 /* HamburgerCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A0F7D0213A11CE00A28D75 /* HamburgerCardCell.swift */; };
 		C2AC3E1C1FA7F83E00CC9D29 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AC3E1B1FA7F83E00CC9D29 /* Session.swift */; };
 		C2B3C0C8202A7153003A9D1C /* AddMoreOptionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B3C0C7202A7153003A9D1C /* AddMoreOptionCell.swift */; };
-		C2B91809208CE3A80030822F /* FRSectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B91808208CE3A80030822F /* FRSectionCell.swift */; };
 		C2B9180D208CE7320030822F /* FeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B9180C208CE7320030822F /* FeedbackViewController.swift */; };
 		C2BB14BA209469CD0081C35D /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2BB14B9209469CD0081C35D /* Utils.swift */; };
 		C2BF44D02033FD630067505A /* UIViewController+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2BF44CF2033FD630067505A /* UIViewController+Shared.swift */; };
@@ -176,6 +165,7 @@
 		0C40B47A22063DDD005BED7B /* DraftEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftEndpoints.swift; sourceTree = "<group>"; };
 		0C40B47C22064263005BED7B /* SessionEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEndpoints.swift; sourceTree = "<group>"; };
 		0C4A24CE227638A700AE0B76 /* UITextField+Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Shared.swift"; sourceTree = "<group>"; };
+		0C50DFBB234050E3001AFC56 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		0C531993215E7C1F00E4EFB7 /* CustomModalPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomModalPresentationController.swift; sourceTree = "<group>"; };
 		0C55CE252233056900E9912C /* HeaderModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderModel.swift; sourceTree = "<group>"; };
 		0C67D34D217BCD9B0000B2A1 /* NoResponsesCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoResponsesCell.swift; sourceTree = "<group>"; };
@@ -188,17 +178,13 @@
 		0CDAF0D221727D4B004DB6EA /* SpaceSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceSectionController.swift; sourceTree = "<group>"; };
 		0CDAF0D421727DA3004DB6EA /* SpaceCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceCell.swift; sourceTree = "<group>"; };
 		0CF647822176970900535573 /* ArrowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrowView.swift; sourceTree = "<group>"; };
-		20FDA08A232BF481006082B8 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		274A52F154DE3D5EFF4998C7 /* Pods-Pollo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pollo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Pollo/Pods-Pollo.debug.xcconfig"; sourceTree = "<group>"; };
 		3DFDE297C79DDA63BD51774D /* Pods-Clicker.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Clicker.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Clicker/Pods-Clicker.debug.xcconfig"; sourceTree = "<group>"; };
-		6321B785209D42A800B3A934 /* FROptionsDropDownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FROptionsDropDownView.swift; sourceTree = "<group>"; };
 		6353FD392086DDC900E16EB2 /* CardController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardController.swift; sourceTree = "<group>"; };
-		636B0F14209D2DDA00769E14 /* QuestionTypeDropDownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionTypeDropDownView.swift; sourceTree = "<group>"; };
 		637FD6922093E5FA007BADF1 /* NameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameView.swift; sourceTree = "<group>"; };
 		6389C94D20858D5400F78003 /* PollPreviewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollPreviewCell.swift; sourceTree = "<group>"; };
 		6389C9512085953F00F78003 /* PollsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollsCell.swift; sourceTree = "<group>"; };
 		6397F8C72174294C00F515DE /* UINavigationController+Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Shared.swift"; sourceTree = "<group>"; };
-		639B4D552093F975009D3309 /* PickQTypeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickQTypeViewController.swift; sourceTree = "<group>"; };
 		63A4A6452094D41600523AE6 /* MCPollBuilderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPollBuilderView.swift; sourceTree = "<group>"; };
 		63A4A6472094D5EF00523AE6 /* FRPollBuilderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FRPollBuilderView.swift; sourceTree = "<group>"; };
 		63A4A64D2094FD7800523AE6 /* DraftCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftCell.swift; sourceTree = "<group>"; };
@@ -222,7 +208,6 @@
 		B638A0A8223833B800D1C2D2 /* PollsSettingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollsSettingModel.swift; sourceTree = "<group>"; };
 		B638A0AA22389FB300D1C2D2 /* SettingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCell.swift; sourceTree = "<group>"; };
 		B638A0AC2238B2E000D1C2D2 /* PollSettingsSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollSettingsSectionController.swift; sourceTree = "<group>"; };
-		B6A23E72232E9F7A0086CC1C /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		BBCCE3D254E127AE7DCF528A /* Pods_Clicker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Clicker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C203E56121332FA30016A147 /* PollsViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PollsViewController+Extension.swift"; sourceTree = "<group>"; };
 		C20B570621388F500091034F /* EmptyStateModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateModel.swift; sourceTree = "<group>"; };
@@ -239,9 +224,6 @@
 		C212179E20281E94007395DA /* UIFont+Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Shared.swift"; sourceTree = "<group>"; };
 		C212EE2C21838D9600D15785 /* QuizModeOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizModeOverlayView.swift; sourceTree = "<group>"; };
 		C21C95B92145D42F00F58874 /* OptionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionModel.swift; sourceTree = "<group>"; };
-		C21C95BB2145D57000F58874 /* FROptionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FROptionModel.swift; sourceTree = "<group>"; };
-		C21C95BD2145D90900F58874 /* FROptionSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FROptionSectionController.swift; sourceTree = "<group>"; };
-		C21C95BF2145DB5400F58874 /* FROptionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FROptionCell.swift; sourceTree = "<group>"; };
 		C21D98802083D32000191103 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		C22D5B5921432411005A0E29 /* MCChoiceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCChoiceModel.swift; sourceTree = "<group>"; };
 		C22D5B5B21432562005A0E29 /* MCChoiceSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCChoiceSectionController.swift; sourceTree = "<group>"; };
@@ -289,9 +271,6 @@
 		C28D0B2E21712C3900FCDE0A /* ActivityIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorView.swift; sourceTree = "<group>"; };
 		C28FE95C21571E4B001AC6AB /* PollBuilderViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PollBuilderViewController+Extension.swift"; sourceTree = "<group>"; };
 		C2900D422146F72900566F25 /* String+Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Shared.swift"; sourceTree = "<group>"; };
-		C2900D44214703E700566F25 /* FRInputModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FRInputModel.swift; sourceTree = "<group>"; };
-		C2900D462147043E00566F25 /* FRInputSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FRInputSectionController.swift; sourceTree = "<group>"; };
-		C2900D48214706C300566F25 /* FRInputCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FRInputCell.swift; sourceTree = "<group>"; };
 		C2A0F7C82139F5E100A28D75 /* PollMiscellaneousSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollMiscellaneousSectionController.swift; sourceTree = "<group>"; };
 		C2A0F7CA213A0BC200A28D75 /* PollMiscellaneousCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollMiscellaneousCell.swift; sourceTree = "<group>"; };
 		C2A0F7CC213A106C00A28D75 /* HamburgerCardModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HamburgerCardModel.swift; sourceTree = "<group>"; };
@@ -299,7 +278,6 @@
 		C2A0F7D0213A11CE00A28D75 /* HamburgerCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HamburgerCardCell.swift; sourceTree = "<group>"; };
 		C2AC3E1B1FA7F83E00CC9D29 /* Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
 		C2B3C0C7202A7153003A9D1C /* AddMoreOptionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMoreOptionCell.swift; sourceTree = "<group>"; };
-		C2B91808208CE3A80030822F /* FRSectionCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FRSectionCell.swift; sourceTree = "<group>"; };
 		C2B9180C208CE7320030822F /* FeedbackViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedbackViewController.swift; sourceTree = "<group>"; };
 		C2BB14B9209469CD0081C35D /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		C2BF44CF2033FD630067505A /* UIViewController+Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Shared.swift"; sourceTree = "<group>"; };
@@ -394,7 +372,6 @@
 			isa = PBXGroup;
 			children = (
 				C20B57182139DDA10091034F /* QuestionSectionController.swift */,
-				C2900D462147043E00566F25 /* FRInputSectionController.swift */,
 				C2649F76214232CF00370454 /* PollOptionsSectionController.swift */,
 				C2A0F7C82139F5E100A28D75 /* PollMiscellaneousSectionController.swift */,
 				C2A0F7CE213A115900A28D75 /* HamburgerCardSectionController.swift */,
@@ -416,7 +393,6 @@
 			children = (
 				0CDAF0D221727D4B004DB6EA /* SpaceSectionController.swift */,
 				C22D5B5B21432562005A0E29 /* MCChoiceSectionController.swift */,
-				C21C95BD2145D90900F58874 /* FROptionSectionController.swift */,
 				C2E1A2632139F0E500087EE4 /* MCResultSectionController.swift */,
 				C26EBB6C21B904D800AC2B60 /* AskQuestionSectionController.swift */,
 			);
@@ -438,8 +414,6 @@
 				C22F66632141B7AA00D4E349 /* SeparatorLineCell.swift */,
 				C2649F782142336D00370454 /* PollOptionsCell.swift */,
 				C22D5B5D214325BE005A0E29 /* MCChoiceCell.swift */,
-				C21C95BF2145DB5400F58874 /* FROptionCell.swift */,
-				C2900D48214706C300566F25 /* FRInputCell.swift */,
 				C26D5F52214F5FE900548255 /* PollsDateCell.swift */,
 			);
 			path = Cards;
@@ -486,15 +460,6 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
-		63C36F2120994148004EBB16 /* Dropdowns */ = {
-			isa = PBXGroup;
-			children = (
-				636B0F14209D2DDA00769E14 /* QuestionTypeDropDownView.swift */,
-				6321B785209D42A800B3A934 /* FROptionsDropDownView.swift */,
-			);
-			path = Dropdowns;
-			sourceTree = "<group>";
-		};
 		770C3962086AA4C584ACE138 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -532,8 +497,6 @@
 				C2A0F7CC213A106C00A28D75 /* HamburgerCardModel.swift */,
 				C22F66612141B75100D4E349 /* SeparatorLineModel.swift */,
 				C2649F742142314B00370454 /* PollOptionsModel.swift */,
-				C21C95BB2145D57000F58874 /* FROptionModel.swift */,
-				C2900D44214703E700566F25 /* FRInputModel.swift */,
 				63ACEC71214B3D2A00D555F1 /* SettingsDataModel.swift */,
 				C28679DC2155A5A300554F7B /* PollBuilderMCOptionModel.swift */,
 				C271A07D2193F58200EF12B4 /* ViewAllModel.swift */,
@@ -620,14 +583,6 @@
 			path = MultipleChoice;
 			sourceTree = "<group>";
 		};
-		C2BF44D22034027A0067505A /* FreeResponse */ = {
-			isa = PBXGroup;
-			children = (
-				C2B91808208CE3A80030822F /* FRSectionCell.swift */,
-			);
-			path = FreeResponse;
-			sourceTree = "<group>";
-		};
 		C2DDE00E20869A0300A85094 /* Polls */ = {
 			isa = PBXGroup;
 			children = (
@@ -673,10 +628,8 @@
 				63ACEC75214D617800D555F1 /* Settings */,
 				6389C94C20858D3300F78003 /* HomeScreen */,
 				638406D12083CBC700483645 /* Cards */,
-				C2BF44D22034027A0067505A /* FreeResponse */,
 				C2BF44D1203402540067505A /* MultipleChoice */,
 				63A4A64C2094FD3500523AE6 /* Drafts */,
-				63C36F2120994148004EBB16 /* Dropdowns */,
 				63A4A6492094DFD000523AE6 /* PollBuilder */,
 				C28AD560205CB7D50053AD62 /* QuestionSectionCell.swift */,
 				C2BF982A206BE1240048468E /* OptionsView.swift */,
@@ -711,7 +664,7 @@
 		C7F923C41F73540600B1E975 /* Pollo */ = {
 			isa = PBXGroup;
 			children = (
-				20FDA08A232BF481006082B8 /* GoogleService-Info.plist */,
+				0C50DFBB234050E3001AFC56 /* GoogleService-Info.plist */,
 				0C40B4732201E52C005BED7B /* Networking */,
 				C7F923C51F73540600B1E975 /* AppDelegate.swift */,
 				C281886C1F7ADE6F00D7E944 /* Models */,
@@ -738,7 +691,6 @@
 				C275A1BD2098BE9100815951 /* EditPollViewController.swift */,
 				C2B9180C208CE7320030822F /* FeedbackViewController.swift */,
 				C21D98802083D32000191103 /* LoginViewController.swift */,
-				639B4D552093F975009D3309 /* PickQTypeViewController.swift */,
 				D13E9091208712A300856DD4 /* PollBuilderViewController.swift */,
 				C28FE95C21571E4B001AC6AB /* PollBuilderViewController+Extension.swift */,
 				C2F48EC22083051A0022FE6B /* PollsViewController.swift */,
@@ -848,7 +800,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0C5C5F92220F9FDA0080F0AA /* Assets.xcassets in Resources */,
-				20FDA08B232BF481006082B8 /* GoogleService-Info.plist in Resources */,
+				0C50DFBC234050E3001AFC56 /* GoogleService-Info.plist in Resources */,
 				D946CA822213D2EA0005AD70 /* testflight_release_notes.txt in Resources */,
 				D13E908B2086BC3200856DD4 /* LaunchScreen.storyboard in Resources */,
 			);
@@ -978,7 +930,6 @@
 			files = (
 				C2649F792142336D00370454 /* PollOptionsCell.swift in Sources */,
 				C2A0F7CB213A0BC200A28D75 /* PollMiscellaneousCell.swift in Sources */,
-				639B4D562093F975009D3309 /* PickQTypeViewController.swift in Sources */,
 				C271A0792193EE2B00EF12B4 /* PollsDateAttendanceCell.swift in Sources */,
 				B638A0A72236F40600D1C2D2 /* HeaderSectionController.swift in Sources */,
 				C271A096219405DE00EF12B4 /* PollsDateAttendanceModel.swift in Sources */,
@@ -1044,17 +995,14 @@
 				63ACEC70214B378E00D555F1 /* SettingsViewController.swift in Sources */,
 				63ACEC72214B3D2A00D555F1 /* SettingsDataModel.swift in Sources */,
 				6353FD3A2086DDC900E16EB2 /* CardController.swift in Sources */,
-				636B0F15209D2DDA00769E14 /* QuestionTypeDropDownView.swift in Sources */,
 				0C1E51FE21711B1B001E07BC /* Date+Shared.swift in Sources */,
 				C26EBB6F21B9051B00AC2B60 /* AskQuestionCell.swift in Sources */,
 				D946CA7E221346860005AD70 /* keys.generated.swift in Sources */,
 				C28AD561205CB7D50053AD62 /* QuestionSectionCell.swift in Sources */,
 				0CCA95E722341529006A3659 /* ExportAttendanceSectionController.swift in Sources */,
 				C2F86664215174E800D045CD /* SessionSectionController.swift in Sources */,
-				6321B786209D42A800B3A934 /* FROptionsDropDownView.swift in Sources */,
 				C28FE95D21571E4B001AC6AB /* PollBuilderViewController+Extension.swift in Sources */,
 				C20B571521390D2A0091034F /* CardCell.swift in Sources */,
-				C2900D472147043E00566F25 /* FRInputSectionController.swift in Sources */,
 				C2A0F7C92139F5E100A28D75 /* PollMiscellaneousSectionController.swift in Sources */,
 				C22D5B5A21432411005A0E29 /* MCChoiceModel.swift in Sources */,
 				C20B57172139D9D70091034F /* QuestionModel.swift in Sources */,
@@ -1069,16 +1017,13 @@
 				C20B571F2139E9F40091034F /* MCResultModel.swift in Sources */,
 				C271A07E2193F58200EF12B4 /* ViewAllModel.swift in Sources */,
 				C2F48EB7208302F90022FE6B /* Socket.swift in Sources */,
-				C2900D49214706C300566F25 /* FRInputCell.swift in Sources */,
 				C2434CB92134715600929C98 /* PollTypeSectionController.swift in Sources */,
 				C25F21E8203F76F2001F540E /* CreateMCOptionCell.swift in Sources */,
-				C2900D45214703E700566F25 /* FRInputModel.swift in Sources */,
 				C22F66642141B7AA00D4E349 /* SeparatorLineCell.swift in Sources */,
 				0C40B4792201E56B005BED7B /* PollEndpoints.swift in Sources */,
 				C26EBB6721B8F46100AC2B60 /* DraftsTitleCell.swift in Sources */,
 				B638A0A52236C2ED00D1C2D2 /* HeaderCell.swift in Sources */,
 				C271A0802193F62800EF12B4 /* ViewAllCell.swift in Sources */,
-				C21C95BE2145D90900F58874 /* FROptionSectionController.swift in Sources */,
 				C2E1A2642139F0E500087EE4 /* MCResultSectionController.swift in Sources */,
 				0C19424D227260AF008CC996 /* Response.swift in Sources */,
 				C7F923C61F73540600B1E975 /* AppDelegate.swift in Sources */,
@@ -1092,9 +1037,7 @@
 				63A4A64E2094FD7800523AE6 /* DraftCell.swift in Sources */,
 				C26EBB6221B8F10F00AC2B60 /* DraftsTitleModel.swift in Sources */,
 				C2CA3A28208309F800E0BDC5 /* User.swift in Sources */,
-				C21C95BC2145D57000F58874 /* FROptionModel.swift in Sources */,
 				C2434CBD2134FFD500929C98 /* PollsDateModel.swift in Sources */,
-				C2B91809208CE3A80030822F /* FRSectionCell.swift in Sources */,
 				C22D5B5C21432562005A0E29 /* MCChoiceSectionController.swift in Sources */,
 				637FD6932093E5FA007BADF1 /* NameView.swift in Sources */,
 				C20B570D213893180091034F /* PollSectionController.swift in Sources */,
@@ -1118,7 +1061,6 @@
 				C26EBB6921B8F54900AC2B60 /* MCPollBuilderView+Extension.swift in Sources */,
 				C2B9180D208CE7320030822F /* FeedbackViewController.swift in Sources */,
 				C7D6AF591F93DE4E003ABA10 /* Constants.swift in Sources */,
-				C21C95C02145DB5400F58874 /* FROptionCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pollo/Views/MultipleChoice/CreateMCOptionCell.swift
+++ b/Pollo/Views/MultipleChoice/CreateMCOptionCell.swift
@@ -39,6 +39,7 @@ class CreateMCOptionCell: UICollectionViewCell, UITextFieldDelegate {
     let filledCircleImageName = "option_filled"
     let isCorrectButtonLeftPadding: CGFloat = 12
     let isCorrectButtonLength: CGFloat = 23
+    let trashIconInset: CGFloat = 13
     let trashIconHeight: CGFloat = 21.5
     let unfilledCircleImageName = "greyEmptyCircle"
     
@@ -72,17 +73,12 @@ class CreateMCOptionCell: UICollectionViewCell, UITextFieldDelegate {
         addOptionTextField.returnKeyType = .done
         addOptionTextField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
         addOptionTextField.delegate = self
-
+        containerView.addSubview(addOptionTextField)
+        
         trashButton = UIButton()
         trashButton.setImage(#imageLiteral(resourceName: "TrashIcon"), for: .normal)
         trashButton.addTarget(self, action: #selector(deleteOption), for: .touchUpInside)
-        
-        let rightTrashView = UIView(frame: CGRect(x: 0, y: 0, width: trashIconHeight + 13, height: contentView.frame.height))
-        addOptionTextField.rightView = rightTrashView
-        addOptionTextField.rightViewMode = .always
-        rightTrashView.addSubview(trashButton)
-        
-        containerView.addSubview(addOptionTextField)
+        containerView.addSubview(trashButton)
 
         setupConstraints()
     }
@@ -107,10 +103,9 @@ class CreateMCOptionCell: UICollectionViewCell, UITextFieldDelegate {
         }
         
         trashButton.snp.updateConstraints { make in
-            make.left.equalToSuperview()
+            make.width.height.equalTo(trashIconHeight)
+            make.right.equalToSuperview().inset(trashIconInset)
             make.centerY.equalToSuperview()
-            make.width.equalTo(trashIconHeight)
-            make.height.equalTo(trashIconHeight)
         }
     }
     
@@ -143,7 +138,7 @@ class CreateMCOptionCell: UICollectionViewCell, UITextFieldDelegate {
     }
 
     @objc func isCorrectButtonTapped() {
-        isCorrect = !isCorrect
+        isCorrect.toggle()
         delegate?.createMCOptionCellDidUpdateIsCorrect(index: index, text: addOptionTextField.text ?? "", isCorrect: isCorrect)
     }
     


### PR DESCRIPTION
This PR fixes a bug in `CreateMCOptionCell` where text field events would not fire and the trash icon would not be visible.

Here is what `PollBuilderViewController` looks like with these changes in place:

![Simulator Screen Shot - iPhone 8 Plus - 2019-09-29 at 16 42 21](https://user-images.githubusercontent.com/27955136/65839144-9c9f2700-e2d8-11e9-98f2-2125d1f4149a.png)
