### PR TITLE
Fix Create Poll Button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,7 @@ fastlane/screenshots
 fastlane/test_output
 
 Secrets/
-Clicker/GoogleService-Info.plist
+Pollo/GoogleService-Info.plist
 
 # Swiftlint
 #.swiftlint.yml

--- a/Pollo.xcodeproj/project.pbxproj
+++ b/Pollo.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		B638A0A9223833B800D1C2D2 /* PollsSettingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B638A0A8223833B800D1C2D2 /* PollsSettingModel.swift */; };
 		B638A0AB22389FB300D1C2D2 /* SettingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B638A0AA22389FB300D1C2D2 /* SettingCell.swift */; };
 		B638A0AD2238B2E000D1C2D2 /* PollSettingsSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B638A0AC2238B2E000D1C2D2 /* PollSettingsSectionController.swift */; };
+		B68EB6A323455ABB008169CB /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = B68EB6A223455ABB008169CB /* GoogleService-Info.plist */; };
 		C203E56221332FA30016A147 /* PollsViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C203E56121332FA30016A147 /* PollsViewController+Extension.swift */; };
 		C20B570721388F500091034F /* EmptyStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20B570621388F500091034F /* EmptyStateModel.swift */; };
 		C20B57092138903B0091034F /* EmptyStateSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20B57082138903B0091034F /* EmptyStateSectionController.swift */; };
@@ -208,6 +209,7 @@
 		B638A0A8223833B800D1C2D2 /* PollsSettingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollsSettingModel.swift; sourceTree = "<group>"; };
 		B638A0AA22389FB300D1C2D2 /* SettingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCell.swift; sourceTree = "<group>"; };
 		B638A0AC2238B2E000D1C2D2 /* PollSettingsSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollSettingsSectionController.swift; sourceTree = "<group>"; };
+		B68EB6A223455ABB008169CB /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		BBCCE3D254E127AE7DCF528A /* Pods_Clicker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Clicker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C203E56121332FA30016A147 /* PollsViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PollsViewController+Extension.swift"; sourceTree = "<group>"; };
 		C20B570621388F500091034F /* EmptyStateModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateModel.swift; sourceTree = "<group>"; };
@@ -664,6 +666,7 @@
 		C7F923C41F73540600B1E975 /* Pollo */ = {
 			isa = PBXGroup;
 			children = (
+				B68EB6A223455ABB008169CB /* GoogleService-Info.plist */,
 				0C50DFBB234050E3001AFC56 /* GoogleService-Info.plist */,
 				0C40B4732201E52C005BED7B /* Networking */,
 				C7F923C51F73540600B1E975 /* AppDelegate.swift */,
@@ -800,6 +803,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0C5C5F92220F9FDA0080F0AA /* Assets.xcassets in Resources */,
+				B68EB6A323455ABB008169CB /* GoogleService-Info.plist in Resources */,
 				0C50DFBC234050E3001AFC56 /* GoogleService-Info.plist in Resources */,
 				D946CA822213D2EA0005AD70 /* testflight_release_notes.txt in Resources */,
 				D13E908B2086BC3200856DD4 /* LaunchScreen.storyboard in Resources */,

--- a/Pollo/ViewControllers/CardController+Extension.swift
+++ b/Pollo/ViewControllers/CardController+Extension.swift
@@ -110,6 +110,7 @@ extension CardController: PollBuilderViewControllerDelegate {
 
         let correct = correctAnswer ?? ""
 
+        session.isLive = true
         // EMIT START QUESTION
         let newPoll = Poll(text: text, answerChoices: answerChoices, type: type, userAnswers: [:], state: state)
         newPoll.createdAt = Date().secondsString
@@ -366,6 +367,7 @@ extension CardController: SocketDelegate {
     }
     
     func emitEndPoll() {
+        session.isLive = false
         socket.socket.emit(Routes.serverEnd, [])
     }
 

--- a/Pollo/ViewControllers/CardController.swift
+++ b/Pollo/ViewControllers/CardController.swift
@@ -170,6 +170,7 @@ class CardController: UIViewController {
         
         if userRole == .admin {
             createPollButton = UIButton()
+            createPollButton.isHidden = session.isLive ?? false
             createPollButton.setImage(#imageLiteral(resourceName: "whiteCreatePoll"), for: .normal)
             createPollButton.addTarget(self, action: #selector(createPollBtnPressed), for: .touchUpInside)
             let createPollBarButton = UIBarButtonItem(customView: createPollButton)

--- a/Pollo/ViewControllers/PollBuilderViewController.swift
+++ b/Pollo/ViewControllers/PollBuilderViewController.swift
@@ -31,7 +31,7 @@ class PollBuilderViewController: UIViewController {
     var dimmingView: UIView!
     var exitButton: UIButton!
     var mcPollBuilder: MCPollBuilderView!
-    var multipleChoiceLabel: UILabel!
+    var createQuestionLabel: UILabel!
     var quizModeOverlayView: QuizModeOverlayView!
     var saveDraftButton: UIButton!
     var startPollButton: UIButton!
@@ -57,6 +57,7 @@ class PollBuilderViewController: UIViewController {
     let buttonsViewHeight: CGFloat = 67.5
     let centerViewHeight: CGFloat = 24
     let centerViewWidth: CGFloat = 135
+    let createQuestionText = "Create Question"
     let draftsButtonWidth: CGFloat = 100
     let edgePadding: CGFloat = 18
     let editDraftModalSize: CGFloat = 50
@@ -125,12 +126,12 @@ class PollBuilderViewController: UIViewController {
         mcPollBuilder.configure(with: self, pollBuilderDelegate: self)
         view.addSubview(mcPollBuilder)
 
-        multipleChoiceLabel = UILabel()
-        multipleChoiceLabel.text = "Multiple Choice"
-        multipleChoiceLabel.font = ._18SemiboldFont
-        multipleChoiceLabel.textAlignment = .center
-        multipleChoiceLabel.textColor = .clickerBlack0
-        view.addSubview(multipleChoiceLabel)
+        createQuestionLabel = UILabel()
+        createQuestionLabel.text = createQuestionText
+        createQuestionLabel.font = ._18SemiboldFont
+        createQuestionLabel.textAlignment = .center
+        createQuestionLabel.textColor = .clickerBlack0
+        view.addSubview(createQuestionLabel)
         
         buttonsView = UIView()
         buttonsView.backgroundColor = .white
@@ -191,7 +192,7 @@ class PollBuilderViewController: UIViewController {
             make.size.equalTo(LayoutConstants.buttonSize)
         }
 
-        multipleChoiceLabel.snp.makeConstraints { make in
+        createQuestionLabel.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.top.equalToSuperview().offset(edgePadding)
         }
@@ -304,7 +305,7 @@ class PollBuilderViewController: UIViewController {
             print("cannot start question before viewdidload")
             return
         }
-        
+
         delegate?.showNavigationBar()
         dismiss(animated: true, completion: nil)
         hideKeyboard()
@@ -312,7 +313,7 @@ class PollBuilderViewController: UIViewController {
         switch questionType { 
         case .multipleChoice:
             answerChoices = mcPollBuilder.getChoices()
-            let question = loadedMCDraft?.text ?? ""
+            let question = mcPollBuilder.questionText ?? ""
             delegate?.startPoll(text: question, type: .multipleChoice, options: mcPollBuilder.getOptions(), state: .live, answerChoices: answerChoices, correctAnswer: correctAnswer, shouldPopViewController: true)
         }
 

--- a/Pollo/ViewControllers/PollsDateViewController+Extension.swift
+++ b/Pollo/ViewControllers/PollsDateViewController+Extension.swift
@@ -85,6 +85,7 @@ extension PollsDateViewController: PollBuilderViewControllerDelegate {
         createPollButton.isUserInteractionEnabled = false
         createPollButton.isHidden = true
 
+        session.isLive = true
         let newPoll = Poll(text: text, answerChoices: answerChoices, type: type, correctAnswer: correctAnswer, userAnswers: [:], state: .live)
         newPoll.createdAt = Date().secondsString
 
@@ -119,7 +120,7 @@ extension PollsDateViewController: PollBuilderViewControllerDelegate {
 extension PollsDateViewController: NameViewDelegate {
     
     func nameViewDidUpdateSessionName() {
-        navigationTitleView.configure(primaryText: session.name, secondaryText: "Code: \(session.code)")
+        navigationTitleView.configure(primaryText: session.name, secondaryText: "Code: \(session.code)", userRole: userRole, delegate: self)
     }
     
 }

--- a/Pollo/ViewControllers/PollsDateViewController.swift
+++ b/Pollo/ViewControllers/PollsDateViewController.swift
@@ -59,7 +59,7 @@ class PollsDateViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         if createPollButton != nil {
-            let livePollExists = pollsDateArray.last?.polls.last?.state == .live
+            let livePollExists = session.isLive ?? false
             createPollButton.isUserInteractionEnabled = !livePollExists
             createPollButton.isHidden = livePollExists
         }
@@ -111,6 +111,7 @@ class PollsDateViewController: UIViewController {
         
         if userRole == .admin {
             createPollButton = UIButton()
+            createPollButton.isHidden = pollsDateArray.last?.polls.last?.state == .live
             createPollButton.setImage(#imageLiteral(resourceName: "whiteCreatePoll"), for: .normal)
             createPollButton.addTarget(self, action: #selector(createPollBtnPressed), for: .touchUpInside)
             let createPollBarButton = UIBarButtonItem(customView: createPollButton)

--- a/Pollo/ViewControllers/PollsViewController.swift
+++ b/Pollo/ViewControllers/PollsViewController.swift
@@ -306,6 +306,7 @@ class PollsViewController: UIViewController {
                 switch result {
                 case .value(let sessionResponse):
                     let session = sessionResponse.data
+                    session.isLive = false
                     self.isListeningToKeyboard = false
                     self.hideNewGroupActivityIndicatorView()
                     let pollsDateViewController = PollsDateViewController(delegate: self, pollsDateArray: [], session: session, userRole: .admin)


### PR DESCRIPTION
Both `createPollButton` and the group controls arrow show up when they are meant to. The test plan was by navigating `pollsViewController`, `pollsDateViewController`, and `cardController` with a poll live and a poll ended. This requires ensuring `session.isLive` is correctly set across multiple ViewControllers. Additionally, in `pollsBuilderViewController` the header label now says `Create Question` and properly loads the title to the Poll.
