### PR TITLE
Update colors to reflect most recent designs

### DIFF
--- a/Pollo.xcodeproj/project.pbxproj
+++ b/Pollo.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		0C40B47B22063DDD005BED7B /* DraftEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C40B47A22063DDD005BED7B /* DraftEndpoints.swift */; };
 		0C40B47D22064263005BED7B /* SessionEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C40B47C22064263005BED7B /* SessionEndpoints.swift */; };
 		0C4A24CF227638A700AE0B76 /* UITextField+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C4A24CE227638A700AE0B76 /* UITextField+Shared.swift */; };
+		0C50CD60234E865A00A93045 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0C50CD5F234E865900A93045 /* GoogleService-Info.plist */; };
 		0C531994215E7C1F00E4EFB7 /* CustomModalPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C531993215E7C1F00E4EFB7 /* CustomModalPresentationController.swift */; };
 		0C55CE262233056900E9912C /* HeaderModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C55CE252233056900E9912C /* HeaderModel.swift */; };
 		0C5C5F92220F9FDA0080F0AA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C7F923CC1F73540600B1E975 /* Assets.xcassets */; };
@@ -27,7 +28,6 @@
 		0CDAF0D321727D4B004DB6EA /* SpaceSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDAF0D221727D4B004DB6EA /* SpaceSectionController.swift */; };
 		0CDAF0D521727DA3004DB6EA /* SpaceCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDAF0D421727DA3004DB6EA /* SpaceCell.swift */; };
 		0CF647832176970900535573 /* ArrowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF647822176970900535573 /* ArrowView.swift */; };
-		20E8A498234C666000874A02 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 20E8A497234C666000874A02 /* GoogleService-Info.plist */; };
 		3BE2EC4CF6A43F972650EC5C /* Pods_Pollo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8812616CD823A168F697E7F4 /* Pods_Pollo.framework */; };
 		6353FD3A2086DDC900E16EB2 /* CardController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6353FD392086DDC900E16EB2 /* CardController.swift */; };
 		637FD6932093E5FA007BADF1 /* NameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637FD6922093E5FA007BADF1 /* NameView.swift */; };
@@ -165,6 +165,7 @@
 		0C40B47A22063DDD005BED7B /* DraftEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftEndpoints.swift; sourceTree = "<group>"; };
 		0C40B47C22064263005BED7B /* SessionEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEndpoints.swift; sourceTree = "<group>"; };
 		0C4A24CE227638A700AE0B76 /* UITextField+Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Shared.swift"; sourceTree = "<group>"; };
+		0C50CD5F234E865900A93045 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		0C531993215E7C1F00E4EFB7 /* CustomModalPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomModalPresentationController.swift; sourceTree = "<group>"; };
 		0C55CE252233056900E9912C /* HeaderModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderModel.swift; sourceTree = "<group>"; };
 		0C67D34D217BCD9B0000B2A1 /* NoResponsesCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoResponsesCell.swift; sourceTree = "<group>"; };
@@ -177,7 +178,6 @@
 		0CDAF0D221727D4B004DB6EA /* SpaceSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceSectionController.swift; sourceTree = "<group>"; };
 		0CDAF0D421727DA3004DB6EA /* SpaceCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceCell.swift; sourceTree = "<group>"; };
 		0CF647822176970900535573 /* ArrowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrowView.swift; sourceTree = "<group>"; };
-		20E8A497234C666000874A02 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		274A52F154DE3D5EFF4998C7 /* Pods-Pollo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pollo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Pollo/Pods-Pollo.debug.xcconfig"; sourceTree = "<group>"; };
 		6353FD392086DDC900E16EB2 /* CardController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardController.swift; sourceTree = "<group>"; };
 		637FD6922093E5FA007BADF1 /* NameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameView.swift; sourceTree = "<group>"; };
@@ -656,7 +656,7 @@
 		C7F923C41F73540600B1E975 /* Pollo */ = {
 			isa = PBXGroup;
 			children = (
-				20E8A497234C666000874A02 /* GoogleService-Info.plist */,
+				0C50CD5F234E865900A93045 /* GoogleService-Info.plist */,
 				0C40B4732201E52C005BED7B /* Networking */,
 				C7F923C51F73540600B1E975 /* AppDelegate.swift */,
 				C281886C1F7ADE6F00D7E944 /* Models */,
@@ -792,7 +792,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0C5C5F92220F9FDA0080F0AA /* Assets.xcassets in Resources */,
-				20E8A498234C666000874A02 /* GoogleService-Info.plist in Resources */,
+				0C50CD60234E865A00A93045 /* GoogleService-Info.plist in Resources */,
 				D946CA822213D2EA0005AD70 /* testflight_release_notes.txt in Resources */,
 				D13E908B2086BC3200856DD4 /* LaunchScreen.storyboard in Resources */,
 			);

--- a/Pollo/AppDelegate.swift
+++ b/Pollo/AppDelegate.swift
@@ -40,8 +40,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, GIDSignInDelegate {
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.makeKeyAndVisible()
         
-        UITextField.appearance().tintColor = .clickerGreen0
-        UITextView.appearance().tintColor = .clickerGreen0
+        UITextField.appearance().tintColor = .polloGreen
+        UITextView.appearance().tintColor = .polloGreen
     }
     
     func setupNavigationController() {
@@ -67,7 +67,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, GIDSignInDelegate {
     
     func setupNavBar() {
         pollsNavigationController.setNavigationBarHidden(true, animated: false)
-        pollsNavigationController.navigationBar.barTintColor = .clickerBlack1
+        pollsNavigationController.navigationBar.barTintColor = .darkestGray
         pollsNavigationController.navigationBar.isTranslucent = false
         
         let backImage = UIImage(named: "back")?.withRenderingMode(.alwaysOriginal)

--- a/Pollo/AppDelegate.swift
+++ b/Pollo/AppDelegate.swift
@@ -67,7 +67,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, GIDSignInDelegate {
     
     func setupNavBar() {
         pollsNavigationController.setNavigationBarHidden(true, animated: false)
-        pollsNavigationController.navigationBar.barTintColor = .darkestGray
+        pollsNavigationController.navigationBar.barTintColor = .darkestGrey
         pollsNavigationController.navigationBar.isTranslucent = false
         
         let backImage = UIImage(named: "back")?.withRenderingMode(.alwaysOriginal)

--- a/Pollo/Extensions/UIColor+Shared.swift
+++ b/Pollo/Extensions/UIColor+Shared.swift
@@ -8,44 +8,30 @@
 import UIKit
 
 extension UIColor {
-
+    
+    @nonobjc static let darkestGray = UIColor(white: 32.0 / 255.0, alpha: 1.0)
+    @nonobjc static let polloGreen = UIColor(red: 41.0 / 255.0, green: 192.0 / 255.0, blue: 158.0 / 255.0, alpha: 1.0)
+    @nonobjc static let blueyGrey = UIColor(red: 158.0 / 255.0, green: 167.0 / 255.0, blue: 179.0 / 255.0, alpha: 1.0)
+    @nonobjc static let grapefruit = UIColor(red: 231.0 / 255.0, green: 99.0 / 255.0, blue: 102.0 / 255.0, alpha: 1.0)
+    @nonobjc static let lightgray = UIColor(white: 236.0 / 255.0, alpha: 1.0)
+    @nonobjc static let lightGreen = UIColor(red: 199.0 / 255.0, green: 239.0 / 255.0, blue: 230.0 / 255.0, alpha: 1.0)
+    @nonobjc static let darkgray = UIColor(white: 61.0 / 255.0, alpha: 1.0)
+    @nonobjc static let mediumGray = UIColor(white: 108.0 / 255.0, alpha: 1.0)
+    @nonobjc static let offWhite = UIColor(white: 250.0 / 255.0, alpha: 1.0)
     @nonobjc static let aquaMarine = UIColor(red: 66/255, green: 219/255, blue: 197/255, alpha: 1.0)
     @nonobjc static let bluishGreen = UIColor(red: 10/255, green: 161/255, blue: 127/255, alpha: 1.0)
     @nonobjc static let charcoalGrey = UIColor(red: 48.0 / 255.0, green: 48.0 / 255.0, blue: 60.0 / 255.0, alpha: 1.0)
     @nonobjc static let clickerBlack0 = UIColor(red: 31/255, green: 44/255, blue: 56/255, alpha: 1.0)
-    @nonobjc static let clickerBlack1 = UIColor(red: 32/255, green: 32/255, blue: 32/255, alpha: 1.0)
-    @nonobjc static let clickerBlack2 = UIColor(red: 32/255, green: 32/255, blue: 32/255, alpha: 0.70)
-    @nonobjc static let clickerBlack3 = UIColor(red: 32/255, green: 32/255, blue: 32/255, alpha: 0.60)
     @nonobjc static let clickerBlue = UIColor(red: 73/255, green: 157/255, blue: 255/255, alpha: 1.0)
-    @nonobjc static let clickerGreen0 = UIColor(red: 0.16, green: 0.75, blue: 0.62, alpha: 1.0)
-    @nonobjc static let clickerGreen1 = UIColor(red: 41/255, green: 192/255, blue: 158/255, alpha: 0.25)
-    @nonobjc static let clickerGreen2 = UIColor(red: 6/255, green: 184/255, blue: 158/255, alpha: 0.19)
-    @nonobjc static let clickerGrey0 = UIColor(red: 32/255, green: 32/255, blue: 32/255, alpha: 1.0)
-    @nonobjc static let clickerGrey1 = UIColor(red: 229/255, green: 231/255, blue: 237/255, alpha: 1.0)
-    @nonobjc static let clickerGrey10 = UIColor(red: 61/255, green: 61/255, blue: 61/255, alpha: 1.0)
-    @nonobjc static let clickerGrey11 = UIColor(red: 120/255, green: 120/255, blue: 120/255, alpha: 1.0)
     @nonobjc static let clickerGrey12 = UIColor(red: 67/255, green: 67/255, blue: 67/255, alpha: 1.0)
     @nonobjc static let clickerGrey13 = UIColor(red: 169/255, green: 177/255, blue: 189/255, alpha: 1.0)
     @nonobjc static let clickerGrey14 = UIColor(red: 151/255, green: 151/255, blue: 151/255, alpha: 1.0)
-    @nonobjc static let clickerGrey2 = UIColor(red: 158/255, green: 167/255, blue: 179/255, alpha: 1.0)
     @nonobjc static let clickerGrey3 = UIColor(red: 122/255, green: 129/255, blue: 139/255, alpha: 1.0)
     @nonobjc static let clickerGrey4 = UIColor(red: 247/255, green: 249/255, blue: 250/255, alpha: 1.0)
     @nonobjc static let clickerGrey5 = UIColor(red: 225/255, green: 225/255, blue: 225/255, alpha: 1.0)
     @nonobjc static let clickerGrey6 = UIColor(red: 240/255, green: 240/255, blue: 240/255, alpha: 1.0)
     @nonobjc static let clickerGrey7 = UIColor(red: 246/255, green: 246/255, blue: 248/255, alpha: 1.0)
     @nonobjc static let clickerGrey8 = UIColor(red: 249/255, green: 249/255, blue: 249/255, alpha: 1.0)
-    @nonobjc static let clickerGrey9 = UIColor(red: 32/255, green: 32/255, blue: 32/255, alpha: 0.6)
-    @nonobjc static let clickerOrange = UIColor(red: 243/255, green: 132/255, blue: 82/255, alpha: 1.0)
     @nonobjc static let clickerRed = UIColor(red: 0.91, green: 0.39, blue: 0.4, alpha: 1.0)
-    @nonobjc static let clickerWhite = UIColor(red: 250/255, green: 250/255, blue: 250/255, alpha: 1.0)
     @nonobjc static let clickerWhite2 = UIColor(white: 234.0 / 255.0, alpha: 0.5)
-    @nonobjc static let grapefruit = UIColor(red: 249.0 / 255.0, green: 93.0 / 255.0, blue: 93.0 / 255.0, alpha: 1.0)
-
-    public static func colorFromCode(_ code: Int) -> UIColor {
-        let red = CGFloat(((code & 0xFF0000) >> 16)) / 255
-        let green = CGFloat(((code & 0xFF00) >> 8)) / 255
-        let blue = CGFloat((code & 0xFF)) / 255
-        
-        return UIColor(red: red, green: green, blue: blue, alpha: 1)
-    }
 }

--- a/Pollo/Extensions/UIColor+Shared.swift
+++ b/Pollo/Extensions/UIColor+Shared.swift
@@ -9,13 +9,13 @@ import UIKit
 
 extension UIColor {
     
-    @nonobjc static let darkestGray = UIColor(white: 32.0 / 255.0, alpha: 1.0)
+    @nonobjc static let darkestGrey = UIColor(white: 32.0 / 255.0, alpha: 1.0)
     @nonobjc static let polloGreen = UIColor(red: 41.0 / 255.0, green: 192.0 / 255.0, blue: 158.0 / 255.0, alpha: 1.0)
-    @nonobjc static let blueyGrey = UIColor(red: 158.0 / 255.0, green: 167.0 / 255.0, blue: 179.0 / 255.0, alpha: 1.0)
+    @nonobjc static let blueGrey = UIColor(red: 158.0 / 255.0, green: 167.0 / 255.0, blue: 179.0 / 255.0, alpha: 1.0)
     @nonobjc static let grapefruit = UIColor(red: 231.0 / 255.0, green: 99.0 / 255.0, blue: 102.0 / 255.0, alpha: 1.0)
-    @nonobjc static let lightgray = UIColor(white: 236.0 / 255.0, alpha: 1.0)
+    @nonobjc static let lightGrey = UIColor(white: 236.0 / 255.0, alpha: 1.0)
     @nonobjc static let lightGreen = UIColor(red: 199.0 / 255.0, green: 239.0 / 255.0, blue: 230.0 / 255.0, alpha: 1.0)
-    @nonobjc static let darkgray = UIColor(white: 61.0 / 255.0, alpha: 1.0)
+    @nonobjc static let darkGrey = UIColor(white: 61.0 / 255.0, alpha: 1.0)
     @nonobjc static let mediumGray = UIColor(white: 108.0 / 255.0, alpha: 1.0)
     @nonobjc static let offWhite = UIColor(white: 250.0 / 255.0, alpha: 1.0)
     @nonobjc static let aquaMarine = UIColor(red: 66/255, green: 219/255, blue: 197/255, alpha: 1.0)

--- a/Pollo/ViewControllers/AttendanceViewController.swift
+++ b/Pollo/ViewControllers/AttendanceViewController.swift
@@ -61,7 +61,7 @@ class AttendanceViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .darkestGray
+        view.backgroundColor = .darkestGrey
         self.title = navigtionTitle
         setupNavBar()
         setupViews()
@@ -130,7 +130,7 @@ class AttendanceViewController: UIViewController {
     }
 
     private func updateExportButton(for isExportable: Bool) {
-        let titleColor: UIColor = isExportable ? .white : .blueyGrey
+        let titleColor: UIColor = isExportable ? .white : .blueGrey
         let backgroundColor: UIColor = isExportable ? .polloGreen : .clear
         let borderColor: UIColor = isExportable ? .polloGreen : UIColor.white.withAlphaComponent(0.9)
         exportButton.setTitleColor(titleColor, for: .normal)

--- a/Pollo/ViewControllers/AttendanceViewController.swift
+++ b/Pollo/ViewControllers/AttendanceViewController.swift
@@ -61,7 +61,7 @@ class AttendanceViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .clickerBlack1
+        view.backgroundColor = .darkestGray
         self.title = navigtionTitle
         setupNavBar()
         setupViews()
@@ -84,7 +84,7 @@ class AttendanceViewController: UIViewController {
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: backImage, style: .done, target: self, action: #selector(goBack))
 
         selectAllBarButtonItem = UIBarButtonItem(title: selectAllBarButtonTitle, style: .plain, target: self, action: #selector(selectAllBtnPressed))
-        selectAllBarButtonItem.tintColor = .clickerGreen0
+        selectAllBarButtonItem.tintColor = .polloGreen
         self.navigationItem.rightBarButtonItem = selectAllBarButtonItem
     }
 
@@ -130,9 +130,9 @@ class AttendanceViewController: UIViewController {
     }
 
     private func updateExportButton(for isExportable: Bool) {
-        let titleColor: UIColor = isExportable ? .white : .clickerGrey2
-        let backgroundColor: UIColor = isExportable ? .clickerGreen0 : .clear
-        let borderColor: UIColor = isExportable ? .clickerGreen0 : UIColor.white.withAlphaComponent(0.9)
+        let titleColor: UIColor = isExportable ? .white : .blueyGrey
+        let backgroundColor: UIColor = isExportable ? .polloGreen : .clear
+        let borderColor: UIColor = isExportable ? .polloGreen : UIColor.white.withAlphaComponent(0.9)
         exportButton.setTitleColor(titleColor, for: .normal)
         exportButton.backgroundColor = backgroundColor
         exportButton.layer.borderColor = borderColor.cgColor

--- a/Pollo/ViewControllers/CardController.swift
+++ b/Pollo/ViewControllers/CardController.swift
@@ -77,7 +77,7 @@ class CardController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        view.backgroundColor = .clickerBlack1
+        view.backgroundColor = .darkestGray
         
         tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTap))
         view.addGestureRecognizer(tapGestureRecognizer)
@@ -121,7 +121,7 @@ class CardController: UIViewController {
         adapter.scrollViewDelegate = self
         
         countLabelBackgroundView = UIView()
-        countLabelBackgroundView.backgroundColor = .clickerGrey10
+        countLabelBackgroundView.backgroundColor = .darkgray
         countLabelBackgroundView.clipsToBounds = true
         countLabelBackgroundView.layer.cornerRadius = countLabelHeight / 2
         view.addSubview(countLabelBackgroundView)

--- a/Pollo/ViewControllers/CardController.swift
+++ b/Pollo/ViewControllers/CardController.swift
@@ -77,7 +77,7 @@ class CardController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        view.backgroundColor = .darkestGray
+        view.backgroundColor = .darkestGrey
         
         tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTap))
         view.addGestureRecognizer(tapGestureRecognizer)
@@ -121,7 +121,7 @@ class CardController: UIViewController {
         adapter.scrollViewDelegate = self
         
         countLabelBackgroundView = UIView()
-        countLabelBackgroundView.backgroundColor = .darkgray
+        countLabelBackgroundView.backgroundColor = .darkGrey
         countLabelBackgroundView.clipsToBounds = true
         countLabelBackgroundView.layer.cornerRadius = countLabelHeight / 2
         view.addSubview(countLabelBackgroundView)

--- a/Pollo/ViewControllers/DeletePollViewController.swift
+++ b/Pollo/ViewControllers/DeletePollViewController.swift
@@ -64,7 +64,7 @@ class DeletePollViewController: UIViewController {
     func setupViews() {
         deleteLabel = UILabel()
         deleteLabel.text = userRole == .admin ? adminDeleteLabelText : memberDeleteLabelText
-        deleteLabel.textColor = .blueyGrey
+        deleteLabel.textColor = .blueGrey
         deleteLabel.textAlignment = .center
         deleteLabel.font = UIFont._16RegularFont
         deleteLabel.numberOfLines = 0
@@ -74,7 +74,7 @@ class DeletePollViewController: UIViewController {
         cancelButton = UIButton()
         cancelButton.setTitle("Cancel", for: .normal)
         cancelButton.setTitleColor(.white, for: .normal)
-        cancelButton.backgroundColor = .blueyGrey
+        cancelButton.backgroundColor = .blueGrey
         cancelButton.layer.cornerRadius = 25
         cancelButton.addTarget(self, action: #selector(backCancelBtnPressed), for: .touchUpInside)
         view.addSubview(cancelButton)

--- a/Pollo/ViewControllers/DeletePollViewController.swift
+++ b/Pollo/ViewControllers/DeletePollViewController.swift
@@ -53,7 +53,7 @@ class DeletePollViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .clickerWhite
+        view.backgroundColor = .offWhite
         self.title = navBarTitle
         
         setupNavBar()
@@ -64,7 +64,7 @@ class DeletePollViewController: UIViewController {
     func setupViews() {
         deleteLabel = UILabel()
         deleteLabel.text = userRole == .admin ? adminDeleteLabelText : memberDeleteLabelText
-        deleteLabel.textColor = .clickerGrey2
+        deleteLabel.textColor = .blueyGrey
         deleteLabel.textAlignment = .center
         deleteLabel.font = UIFont._16RegularFont
         deleteLabel.numberOfLines = 0
@@ -74,7 +74,7 @@ class DeletePollViewController: UIViewController {
         cancelButton = UIButton()
         cancelButton.setTitle("Cancel", for: .normal)
         cancelButton.setTitleColor(.white, for: .normal)
-        cancelButton.backgroundColor = .clickerGrey2
+        cancelButton.backgroundColor = .blueyGrey
         cancelButton.layer.cornerRadius = 25
         cancelButton.addTarget(self, action: #selector(backCancelBtnPressed), for: .touchUpInside)
         view.addSubview(cancelButton)

--- a/Pollo/ViewControllers/EditNameViewController.swift
+++ b/Pollo/ViewControllers/EditNameViewController.swift
@@ -41,7 +41,7 @@ class EditNameViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .clickerWhite
+        view.backgroundColor = .offWhite
         self.title = "Edit Name"
         
         // Add Keyboard Handlers

--- a/Pollo/ViewControllers/EditPollViewController.swift
+++ b/Pollo/ViewControllers/EditPollViewController.swift
@@ -73,7 +73,7 @@ class EditPollViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .clickerWhite
+        view.backgroundColor = .offWhite
         setupNavBar()
         setupViews()
         setupConstraints()

--- a/Pollo/ViewControllers/FeedbackViewController.swift
+++ b/Pollo/ViewControllers/FeedbackViewController.swift
@@ -60,7 +60,7 @@ class FeedbackViewController: UIViewController, WKUIDelegate {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         if type == .pollsViewController {
-            self.navigationController?.navigationBar.barTintColor = .clickerBlack1
+            self.navigationController?.navigationBar.barTintColor = .darkestGray
             self.navigationController?.setNavigationBarHidden(true, animated: false)
         }
     }

--- a/Pollo/ViewControllers/FeedbackViewController.swift
+++ b/Pollo/ViewControllers/FeedbackViewController.swift
@@ -60,7 +60,7 @@ class FeedbackViewController: UIViewController, WKUIDelegate {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         if type == .pollsViewController {
-            self.navigationController?.navigationBar.barTintColor = .darkestGray
+            self.navigationController?.navigationBar.barTintColor = .darkestGrey
             self.navigationController?.setNavigationBarHidden(true, animated: false)
         }
     }

--- a/Pollo/ViewControllers/GroupControlsViewController.swift
+++ b/Pollo/ViewControllers/GroupControlsViewController.swift
@@ -78,10 +78,10 @@ class GroupControlsViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .darkestGray
+        view.backgroundColor = .darkestGrey
 
-        spaceOne = SpaceModel(space: spaceOneHeight, backgroundColor: .darkestGray)
-        spaceTwo = SpaceModel(space: spaceTwoHeight, backgroundColor: .darkestGray)
+        spaceOne = SpaceModel(space: spaceOneHeight, backgroundColor: .darkestGrey)
+        spaceTwo = SpaceModel(space: spaceTwoHeight, backgroundColor: .darkestGrey)
 
         attendanceHeader = HeaderModel(title: attendanceHeaderLabel)
         

--- a/Pollo/ViewControllers/GroupControlsViewController.swift
+++ b/Pollo/ViewControllers/GroupControlsViewController.swift
@@ -78,10 +78,10 @@ class GroupControlsViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .clickerBlack1
+        view.backgroundColor = .darkestGray
 
-        spaceOne = SpaceModel(space: spaceOneHeight, backgroundColor: .clickerBlack1)
-        spaceTwo = SpaceModel(space: spaceTwoHeight, backgroundColor: .clickerBlack1)
+        spaceOne = SpaceModel(space: spaceOneHeight, backgroundColor: .darkestGray)
+        spaceTwo = SpaceModel(space: spaceTwoHeight, backgroundColor: .darkestGray)
 
         attendanceHeader = HeaderModel(title: attendanceHeaderLabel)
         

--- a/Pollo/ViewControllers/PollBuilderViewController+Extension.swift
+++ b/Pollo/ViewControllers/PollBuilderViewController+Extension.swift
@@ -17,11 +17,11 @@ extension PollBuilderViewController: PollBuilderViewDelegate {
     func updateCanDraft(_ canDraft: Bool) {
         self.canDraft = canDraft
         if canDraft {
-            saveDraftButton.setTitleColor(.clickerGreen0, for: .normal)
+            saveDraftButton.setTitleColor(.polloGreen, for: .normal)
             saveDraftButton.backgroundColor = .clear
-            saveDraftButton.layer.borderColor = UIColor.clickerGreen0.cgColor
+            saveDraftButton.layer.borderColor = UIColor.polloGreen.cgColor
         } else {
-            saveDraftButton.setTitleColor(.clickerGrey2, for: .normal)
+            saveDraftButton.setTitleColor(.blueyGrey, for: .normal)
             saveDraftButton.backgroundColor = .clickerGrey6
             saveDraftButton.layer.borderColor = UIColor.clickerGrey6.cgColor
         }

--- a/Pollo/ViewControllers/PollBuilderViewController+Extension.swift
+++ b/Pollo/ViewControllers/PollBuilderViewController+Extension.swift
@@ -21,7 +21,7 @@ extension PollBuilderViewController: PollBuilderViewDelegate {
             saveDraftButton.backgroundColor = .clear
             saveDraftButton.layer.borderColor = UIColor.polloGreen.cgColor
         } else {
-            saveDraftButton.setTitleColor(.blueyGrey, for: .normal)
+            saveDraftButton.setTitleColor(.blueGrey, for: .normal)
             saveDraftButton.backgroundColor = .clickerGrey6
             saveDraftButton.layer.borderColor = UIColor.clickerGrey6.cgColor
         }

--- a/Pollo/ViewControllers/PollBuilderViewController.swift
+++ b/Pollo/ViewControllers/PollBuilderViewController.swift
@@ -78,7 +78,7 @@ class PollBuilderViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        view.backgroundColor = .clickerWhite
+        view.backgroundColor = .offWhite
         questionType = .multipleChoice
         view.layer.masksToBounds = true
         view.layer.cornerRadius = 15
@@ -155,7 +155,7 @@ class PollBuilderViewController: UIViewController {
         startPollButton.setTitle(startPollButtonTitle, for: .normal)
         startPollButton.setTitleColor(.white, for: .normal)
         startPollButton.titleLabel?.font = ._16SemiboldFont
-        startPollButton.backgroundColor = .clickerGreen0
+        startPollButton.backgroundColor = .polloGreen
         startPollButton.layer.cornerRadius = buttonHeight / 2
         startPollButton.addTarget(self, action: #selector(startPoll), for: .touchUpInside)
         buttonsView.addSubview(startPollButton)

--- a/Pollo/ViewControllers/PollsDateViewController.swift
+++ b/Pollo/ViewControllers/PollsDateViewController.swift
@@ -51,7 +51,7 @@ class PollsDateViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        view.backgroundColor = .darkestGray
+        view.backgroundColor = .darkestGrey
         setupViews()
         setupNavBar()
         self.socket = Socket(id: "\(session.id)", delegate: self)

--- a/Pollo/ViewControllers/PollsDateViewController.swift
+++ b/Pollo/ViewControllers/PollsDateViewController.swift
@@ -51,7 +51,7 @@ class PollsDateViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        view.backgroundColor = .clickerBlack1
+        view.backgroundColor = .darkestGray
         setupViews()
         setupNavBar()
         self.socket = Socket(id: "\(session.id)", delegate: self)

--- a/Pollo/ViewControllers/PollsViewController.swift
+++ b/Pollo/ViewControllers/PollsViewController.swift
@@ -113,7 +113,7 @@ class PollsViewController: UIViewController {
         titleLabel = UILabel()
         titleLabel.text = titleLabelText
         titleLabel.font = ._30HeavyFont
-        titleLabel.textColor = .darkestGray
+        titleLabel.textColor = .darkestGrey
         view.addSubview(titleLabel)
         
         pollsOptionsView = OptionsView(frame: .zero, options: [joinedPollsOptionsText, createdPollsOptionsText], sliderBarDelegate: self)
@@ -162,7 +162,7 @@ class PollsViewController: UIViewController {
         view.addSubview(dimmingView)
         
         joinSessionContainerView = UIView()
-        joinSessionContainerView.backgroundColor = .darkestGray
+        joinSessionContainerView.backgroundColor = .darkestGrey
         view.addSubview(joinSessionContainerView)
         
         joinSessionButton = UIButton()
@@ -170,7 +170,7 @@ class PollsViewController: UIViewController {
         joinSessionButton.setTitleColor(.white, for: .normal)
         joinSessionButton.titleLabel?.font = ._16SemiboldFont
         joinSessionButton.titleLabel?.textAlignment = .center
-        joinSessionButton.backgroundColor = .blueyGrey
+        joinSessionButton.backgroundColor = .blueGrey
         joinSessionButton.layer.cornerRadius = codeTextFieldHeight / 2
         joinSessionButton.addTarget(self, action: #selector(joinSession), for: .touchUpInside)
         joinSessionButton.alpha = 0.5
@@ -193,7 +193,7 @@ class PollsViewController: UIViewController {
         joinSessionContainerView.addSubview(codeTextField)
         
         bottomPaddingView = UIView()
-        bottomPaddingView.backgroundColor = .darkestGray
+        bottomPaddingView.backgroundColor = .darkestGrey
         view.addSubview(bottomPaddingView)
     }
     
@@ -402,7 +402,7 @@ class PollsViewController: UIViewController {
     
     func updateJoinSessionButton(canJoin: Bool) {
         UIView.animate(withDuration: joinSessionButtonAnimationDuration) {
-            self.joinSessionButton.backgroundColor = canJoin ? .polloGreen : .blueyGrey
+            self.joinSessionButton.backgroundColor = canJoin ? .polloGreen : .blueGrey
             self.joinSessionButton.alpha = canJoin ? 1.0 : 0.5
         }
     }

--- a/Pollo/ViewControllers/PollsViewController.swift
+++ b/Pollo/ViewControllers/PollsViewController.swift
@@ -113,7 +113,7 @@ class PollsViewController: UIViewController {
         titleLabel = UILabel()
         titleLabel.text = titleLabelText
         titleLabel.font = ._30HeavyFont
-        titleLabel.textColor = .clickerBlack1
+        titleLabel.textColor = .darkestGray
         view.addSubview(titleLabel)
         
         pollsOptionsView = OptionsView(frame: .zero, options: [joinedPollsOptionsText, createdPollsOptionsText], sliderBarDelegate: self)
@@ -162,7 +162,7 @@ class PollsViewController: UIViewController {
         view.addSubview(dimmingView)
         
         joinSessionContainerView = UIView()
-        joinSessionContainerView.backgroundColor = .clickerBlack1
+        joinSessionContainerView.backgroundColor = .darkestGray
         view.addSubview(joinSessionContainerView)
         
         joinSessionButton = UIButton()
@@ -170,7 +170,7 @@ class PollsViewController: UIViewController {
         joinSessionButton.setTitleColor(.white, for: .normal)
         joinSessionButton.titleLabel?.font = ._16SemiboldFont
         joinSessionButton.titleLabel?.textAlignment = .center
-        joinSessionButton.backgroundColor = .clickerGrey2
+        joinSessionButton.backgroundColor = .blueyGrey
         joinSessionButton.layer.cornerRadius = codeTextFieldHeight / 2
         joinSessionButton.addTarget(self, action: #selector(joinSession), for: .touchUpInside)
         joinSessionButton.alpha = 0.5
@@ -193,7 +193,7 @@ class PollsViewController: UIViewController {
         joinSessionContainerView.addSubview(codeTextField)
         
         bottomPaddingView = UIView()
-        bottomPaddingView.backgroundColor = .clickerBlack1
+        bottomPaddingView.backgroundColor = .darkestGray
         view.addSubview(bottomPaddingView)
     }
     
@@ -402,7 +402,7 @@ class PollsViewController: UIViewController {
     
     func updateJoinSessionButton(canJoin: Bool) {
         UIView.animate(withDuration: joinSessionButtonAnimationDuration) {
-            self.joinSessionButton.backgroundColor = canJoin ? .clickerGreen0 : .clickerGrey2
+            self.joinSessionButton.backgroundColor = canJoin ? .polloGreen : .blueyGrey
             self.joinSessionButton.alpha = canJoin ? 1.0 : 0.5
         }
     }

--- a/Pollo/Views/Cards/EmptyStateCell.swift
+++ b/Pollo/Views/Cards/EmptyStateCell.swift
@@ -172,7 +172,7 @@ class EmptyStateCell: UICollectionViewCell {
     // MARK: - Configure
     func configure(for emptyStateModel: EmptyStateModel, session: Session?, shouldDisplayNameView: Bool?, nameViewDelegate: NameViewDelegate?) {
         self.emptyStateModel = emptyStateModel
-        subtitleLabel.textColor = .blueyGrey
+        subtitleLabel.textColor = .blueGrey
         switch emptyStateModel.type {
         case .pollsViewController(let pollType):
             switch pollType {

--- a/Pollo/Views/Cards/EmptyStateCell.swift
+++ b/Pollo/Views/Cards/EmptyStateCell.swift
@@ -172,7 +172,7 @@ class EmptyStateCell: UICollectionViewCell {
     // MARK: - Configure
     func configure(for emptyStateModel: EmptyStateModel, session: Session?, shouldDisplayNameView: Bool?, nameViewDelegate: NameViewDelegate?) {
         self.emptyStateModel = emptyStateModel
-        subtitleLabel.textColor = .clickerGrey2
+        subtitleLabel.textColor = .blueyGrey
         switch emptyStateModel.type {
         case .pollsViewController(let pollType):
             switch pollType {

--- a/Pollo/Views/Cards/HamburgerCardCell.swift
+++ b/Pollo/Views/Cards/HamburgerCardCell.swift
@@ -25,7 +25,7 @@ class HamburgerCardCell: UICollectionViewCell {
         switch hamburgerCardModel.state {
         case .top:
             contentView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-            contentView.backgroundColor = .clickerWhite
+            contentView.backgroundColor = .offWhite
         case .bottom:
             contentView.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
             contentView.backgroundColor = .white

--- a/Pollo/Views/Cards/MCChoiceCell.swift
+++ b/Pollo/Views/Cards/MCChoiceCell.swift
@@ -40,10 +40,10 @@ class MCChoiceCell: UICollectionViewCell {
     func setupViews() {
         optionButton = UIButton()
         optionButton.layer.cornerRadius = optionButtonCornerRadius
-        optionButton.layer.borderColor = UIColor.clickerGreen0.cgColor
+        optionButton.layer.borderColor = UIColor.polloGreen.cgColor
         optionButton.layer.borderWidth = optionButtonBorderWidth
         optionButton.clipsToBounds = true
-        optionButton.setTitleColor(.clickerGreen0, for: .normal)
+        optionButton.setTitleColor(.polloGreen, for: .normal)
         optionButton.titleLabel?.font = UIFont.systemFont(ofSize: optionButtonFontSize, weight: .medium)
         optionButton.addTarget(self, action: #selector(optionButtonWasPressed), for: .touchUpInside)
         contentView.addSubview(optionButton)
@@ -91,21 +91,21 @@ class MCChoiceCell: UICollectionViewCell {
     }
     
     func configureForEndedPoll(isSelected: Bool) {
-        let optionButtonBackgroundColor: UIColor = isSelected ? .clickerGreen1 : .white
-        let optionButtonTitleColor: UIColor = isSelected ? .white : .clickerGreen1
+        let optionButtonBackgroundColor: UIColor = isSelected ? .lightGreen : .white
+        let optionButtonTitleColor: UIColor = isSelected ? .white : .lightGreen
         optionButton.backgroundColor = optionButtonBackgroundColor
         optionButton.setTitleColor(optionButtonTitleColor, for: .normal)
-        optionButton.layer.borderColor = UIColor.clickerGreen1.cgColor
+        optionButton.layer.borderColor = UIColor.lightGreen.cgColor
     }
     
     func selectChoice() {
-        optionButton.backgroundColor = .clickerGreen0
+        optionButton.backgroundColor = .polloGreen
         optionButton.setTitleColor(.white, for: .normal)
     }
     
     func deselectChoice() {
         optionButton.backgroundColor = .white
-        optionButton.setTitleColor(.clickerGreen0, for: .normal)
+        optionButton.setTitleColor(.polloGreen, for: .normal)
     }
     
     required init?(coder aDecoder: NSCoder) {

--- a/Pollo/Views/Cards/MCResultCell.swift
+++ b/Pollo/Views/Cards/MCResultCell.swift
@@ -64,7 +64,7 @@ class MCResultCell: UICollectionViewCell {
         numSelectedLabel.font = UIFont.systemFont(ofSize: labelFontSize, weight: .medium)
         numSelectedLabel.backgroundColor = .clear
         numSelectedLabel.textAlignment = .right
-        numSelectedLabel.textColor = .blueyGrey
+        numSelectedLabel.textColor = .blueGrey
         containerView.addSubview(numSelectedLabel)
 
         highlightView = UIView()
@@ -159,10 +159,10 @@ class MCResultCell: UICollectionViewCell {
                 if correctAnswer != "" {
                     if answer == correctAnswer {
                         showCorrectAnswer = true
-                        highlightView.backgroundColor = isSelected ? .polloGreen : .lightgray
+                        highlightView.backgroundColor = isSelected ? .polloGreen : .lightGrey
                         optionLabel.textColor = .black
                     } else {
-                        highlightView.backgroundColor = isSelected ? .grapefruit : .lightgray
+                        highlightView.backgroundColor = isSelected ? .grapefruit : .lightGrey
                         optionLabel.textColor = .black
                     }
                 } else {

--- a/Pollo/Views/Cards/MCResultCell.swift
+++ b/Pollo/Views/Cards/MCResultCell.swift
@@ -60,7 +60,7 @@ class MCResultCell: UICollectionViewCell {
         path.append(innerPart)
         innerShadow.shadowPath = path.cgPath
         innerShadow.masksToBounds = true
-        innerShadow.shadowColor = UIColor.clickerWhite2.cgColor
+        innerShadow.shadowColor = UIColor.offWhite.cgColor
         innerShadow.shadowOffset = CGSize.zero
         innerShadow.shadowOpacity = 1
         innerShadow.shadowRadius = 2.5
@@ -78,7 +78,7 @@ class MCResultCell: UICollectionViewCell {
         numSelectedLabel.font = UIFont.systemFont(ofSize: labelFontSize, weight: .medium)
         numSelectedLabel.backgroundColor = .clear
         numSelectedLabel.textAlignment = .right
-        numSelectedLabel.textColor = .clickerGrey2
+        numSelectedLabel.textColor = .blueyGrey
         containerView.addSubview(numSelectedLabel)
 
         highlightView = UIView()
@@ -165,7 +165,7 @@ class MCResultCell: UICollectionViewCell {
         self.correctAnswer = correctAnswer
         switch userRole {
         case .admin:
-            highlightView.backgroundColor = .clickerGreen0
+            highlightView.backgroundColor = .polloGreen
         case .member:
             let isSelected = resultModel.isSelected
             let answer = intToMCOption(resultModel.choiceIndex)
@@ -173,18 +173,18 @@ class MCResultCell: UICollectionViewCell {
                 if correctAnswer != "" {
                     if answer == correctAnswer {
                         showCorrectAnswer = true
-                        highlightView.backgroundColor = isSelected ? .clickerGreen0 : .clickerGrey5
+                        highlightView.backgroundColor = isSelected ? .polloGreen : .lightgray
                         optionLabel.textColor = .black
                     } else {
-                        highlightView.backgroundColor = isSelected ? .grapefruit : .clickerGrey5
-                        optionLabel.textColor = isSelected ? .black : .clickerGrey2
+                        highlightView.backgroundColor = isSelected ? .grapefruit : .lightgray
+                        optionLabel.textColor = .black
                     }
                 } else {
-                    highlightView.backgroundColor = isSelected ? .clickerGreen0 : .clickerGreen1
+                    highlightView.backgroundColor = isSelected ? .polloGreen : .lightGreen
                     optionLabel.textColor = .black
                 }
             } else {
-                highlightView.backgroundColor = isSelected ? .clickerGreen0 : .clickerGreen1
+                highlightView.backgroundColor = isSelected ? .polloGreen : .lightGreen
             }
         }
     }

--- a/Pollo/Views/Cards/MCResultCell.swift
+++ b/Pollo/Views/Cards/MCResultCell.swift
@@ -52,20 +52,6 @@ class MCResultCell: UICollectionViewCell {
         containerView.layer.borderColor = UIColor.clickerGrey5.cgColor
         containerView.layer.borderWidth = containerViewBorderWidth
         containerView.clipsToBounds = true
-        
-        innerShadow = CALayer()
-        innerShadow.frame = CGRect(x: 0, y: 0, width: contentView.frame.width - LayoutConstants.pollOptionsPadding * 2, height: contentView.frame.height)
-        let path = UIBezierPath(rect: innerShadow.bounds.insetBy(dx: -20, dy: -20))
-        let innerPart = UIBezierPath(rect: innerShadow.bounds).reversing()
-        path.append(innerPart)
-        innerShadow.shadowPath = path.cgPath
-        innerShadow.masksToBounds = true
-        innerShadow.shadowColor = UIColor.offWhite.cgColor
-        innerShadow.shadowOffset = CGSize.zero
-        innerShadow.shadowOpacity = 1
-        innerShadow.shadowRadius = 2.5
-        containerView.layer.addSublayer(innerShadow)
-        
         contentView.addSubview(containerView)
         
         optionLabel = UILabel()

--- a/Pollo/Views/Cards/NoResponsesCell.swift
+++ b/Pollo/Views/Cards/NoResponsesCell.swift
@@ -21,7 +21,7 @@ class NoResponsesCell: UICollectionViewCell {
         
         noResponsesLabel = UILabel()
         noResponsesLabel.text = noResponsesText
-        noResponsesLabel.textColor = .blueyGrey
+        noResponsesLabel.textColor = .blueGrey
         noResponsesLabel.font = ._12MediumFont
         noResponsesLabel.textAlignment = .center
         contentView.addSubview(noResponsesLabel)

--- a/Pollo/Views/Cards/NoResponsesCell.swift
+++ b/Pollo/Views/Cards/NoResponsesCell.swift
@@ -21,7 +21,7 @@ class NoResponsesCell: UICollectionViewCell {
         
         noResponsesLabel = UILabel()
         noResponsesLabel.text = noResponsesText
-        noResponsesLabel.textColor = .clickerGrey2
+        noResponsesLabel.textColor = .blueyGrey
         noResponsesLabel.font = ._12MediumFont
         noResponsesLabel.textAlignment = .center
         contentView.addSubview(noResponsesLabel)

--- a/Pollo/Views/Cards/PollMiscellaneousCell.swift
+++ b/Pollo/Views/Cards/PollMiscellaneousCell.swift
@@ -35,7 +35,7 @@ class PollMiscellaneousCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        contentView.backgroundColor = .clickerWhite
+        contentView.backgroundColor = .offWhite
         setupViews()
     }
     
@@ -46,12 +46,12 @@ class PollMiscellaneousCell: UICollectionViewCell {
         contentView.addSubview(iconImageView)
         
         descriptionLabel = UILabel()
-        descriptionLabel.textColor = .clickerGrey2
+        descriptionLabel.textColor = .blueyGrey
         descriptionLabel.font = UIFont.systemFont(ofSize: labelFontSize, weight: .semibold)
         contentView.addSubview(descriptionLabel)
         
         totalVotesLabel = UILabel()
-        totalVotesLabel.textColor = .clickerGrey2
+        totalVotesLabel.textColor = .blueyGrey
         totalVotesLabel.font = UIFont.systemFont(ofSize: labelFontSize, weight: .semibold)
         contentView.addSubview(totalVotesLabel)
     }

--- a/Pollo/Views/Cards/PollMiscellaneousCell.swift
+++ b/Pollo/Views/Cards/PollMiscellaneousCell.swift
@@ -46,12 +46,12 @@ class PollMiscellaneousCell: UICollectionViewCell {
         contentView.addSubview(iconImageView)
         
         descriptionLabel = UILabel()
-        descriptionLabel.textColor = .blueyGrey
+        descriptionLabel.textColor = .blueGrey
         descriptionLabel.font = UIFont.systemFont(ofSize: labelFontSize, weight: .semibold)
         contentView.addSubview(descriptionLabel)
         
         totalVotesLabel = UILabel()
-        totalVotesLabel.textColor = .blueyGrey
+        totalVotesLabel.textColor = .blueGrey
         totalVotesLabel.font = UIFont.systemFont(ofSize: labelFontSize, weight: .semibold)
         contentView.addSubview(totalVotesLabel)
     }

--- a/Pollo/Views/Cards/PollsDateCell.swift
+++ b/Pollo/Views/Cards/PollsDateCell.swift
@@ -28,7 +28,7 @@ class PollsDateCell: UICollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        backgroundColor = .clickerBlack1
+        backgroundColor = .darkestGray
         
         setupViews()
     }
@@ -36,7 +36,7 @@ class PollsDateCell: UICollectionViewCell {
     // MARK: - Layout
     func setupViews() {
         greyView = UIView()
-        greyView.backgroundColor = .clickerGrey10
+        greyView.backgroundColor = .darkgray
         greyView.layer.cornerRadius = cellCornerRadius
         contentView.addSubview(greyView)
 

--- a/Pollo/Views/Cards/PollsDateCell.swift
+++ b/Pollo/Views/Cards/PollsDateCell.swift
@@ -28,7 +28,7 @@ class PollsDateCell: UICollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        backgroundColor = .darkestGray
+        backgroundColor = .darkestGrey
         
         setupViews()
     }
@@ -36,7 +36,7 @@ class PollsDateCell: UICollectionViewCell {
     // MARK: - Layout
     func setupViews() {
         greyView = UIView()
-        greyView.backgroundColor = .darkgray
+        greyView.backgroundColor = .darkGrey
         greyView.layer.cornerRadius = cellCornerRadius
         contentView.addSubview(greyView)
 

--- a/Pollo/Views/Cards/QuestionCell.swift
+++ b/Pollo/Views/Cards/QuestionCell.swift
@@ -30,7 +30,7 @@ class QuestionCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        contentView.backgroundColor = .clickerWhite
+        contentView.backgroundColor = .offWhite
         setupViews()
     }
     
@@ -82,7 +82,7 @@ class QuestionCell: UICollectionViewCell {
         questionLabel.textAlignment = userRole == .admin ? .left : .center
         let isUntitledPoll = questionModel.question == ""
         questionLabel.text = isUntitledPoll ? untitledPollString : questionModel.question
-        questionLabel.textColor = isUntitledPoll ? .clickerGrey2 : .black
+        questionLabel.textColor = isUntitledPoll ? .blueyGrey : .black
         questionLabel.alpha = isUntitledPoll ? 0.5 : 1.0
     }
     

--- a/Pollo/Views/Cards/QuestionCell.swift
+++ b/Pollo/Views/Cards/QuestionCell.swift
@@ -82,7 +82,7 @@ class QuestionCell: UICollectionViewCell {
         questionLabel.textAlignment = userRole == .admin ? .left : .center
         let isUntitledPoll = questionModel.question == ""
         questionLabel.text = isUntitledPoll ? untitledPollString : questionModel.question
-        questionLabel.textColor = isUntitledPoll ? .blueyGrey : .black
+        questionLabel.textColor = isUntitledPoll ? .blueGrey : .black
         questionLabel.alpha = isUntitledPoll ? 0.5 : 1.0
     }
     

--- a/Pollo/Views/Drafts/DraftCell.swift
+++ b/Pollo/Views/Drafts/DraftCell.swift
@@ -75,7 +75,7 @@ class DraftCell: UICollectionViewCell {
         questionLabel.font = ._18SemiboldFont
         questionLabel.textAlignment = .left
         questionLabel.backgroundColor = .clear
-        questionLabel.textColor = .blueyGrey
+        questionLabel.textColor = .blueGrey
         questionLabel.numberOfLines = questionLabelMaxNumLines
         questionLabel.lineBreakMode = .byTruncatingTail
         contentView.addSubview(questionLabel)
@@ -91,7 +91,7 @@ class DraftCell: UICollectionViewCell {
         contentView.addSubview(editImageView)
 
         draftTypeLabel = UILabel()
-        draftTypeLabel.textColor = .blueyGrey
+        draftTypeLabel.textColor = .blueGrey
         draftTypeLabel.font = ._12SemiboldFont
         contentView.addSubview(draftTypeLabel)
     }

--- a/Pollo/Views/Drafts/DraftCell.swift
+++ b/Pollo/Views/Drafts/DraftCell.swift
@@ -75,7 +75,7 @@ class DraftCell: UICollectionViewCell {
         questionLabel.font = ._18SemiboldFont
         questionLabel.textAlignment = .left
         questionLabel.backgroundColor = .clear
-        questionLabel.textColor = .clickerGrey2
+        questionLabel.textColor = .blueyGrey
         questionLabel.numberOfLines = questionLabelMaxNumLines
         questionLabel.lineBreakMode = .byTruncatingTail
         contentView.addSubview(questionLabel)
@@ -91,7 +91,7 @@ class DraftCell: UICollectionViewCell {
         contentView.addSubview(editImageView)
 
         draftTypeLabel = UILabel()
-        draftTypeLabel.textColor = .clickerGrey2
+        draftTypeLabel.textColor = .blueyGrey
         draftTypeLabel.font = ._12SemiboldFont
         contentView.addSubview(draftTypeLabel)
     }

--- a/Pollo/Views/Drafts/DraftsTitleCell.swift
+++ b/Pollo/Views/Drafts/DraftsTitleCell.swift
@@ -37,7 +37,7 @@ class DraftsTitleCell: UICollectionViewCell {
     }
 
     func shouldLightenText(_ shouldLighten: Bool) {
-        let textColor: UIColor = shouldLighten ? .clickerGrey2 : .black
+        let textColor: UIColor = shouldLighten ? .blueyGrey : .black
         draftsLabel.textColor = textColor
     }
     

--- a/Pollo/Views/Drafts/DraftsTitleCell.swift
+++ b/Pollo/Views/Drafts/DraftsTitleCell.swift
@@ -37,7 +37,7 @@ class DraftsTitleCell: UICollectionViewCell {
     }
 
     func shouldLightenText(_ shouldLighten: Bool) {
-        let textColor: UIColor = shouldLighten ? .blueyGrey : .black
+        let textColor: UIColor = shouldLighten ? .blueGrey : .black
         draftsLabel.textColor = textColor
     }
     

--- a/Pollo/Views/GroupControls/ExportButtonCell.swift
+++ b/Pollo/Views/GroupControls/ExportButtonCell.swift
@@ -49,9 +49,9 @@ class ExportButtonCell: UICollectionViewCell {
     }
 
     func configure(for isExportable: Bool) {
-        let titleColor: UIColor = isExportable ? .white : .clickerGrey2
-        let backgroundColor: UIColor = isExportable ? .clickerGreen0 : .clear
-        let borderColor: UIColor = isExportable ? .clickerGreen0 : UIColor.white.withAlphaComponent(0.9)
+        let titleColor: UIColor = isExportable ? .white : .blueyGrey
+        let backgroundColor: UIColor = isExportable ? .polloGreen : .clear
+        let borderColor: UIColor = isExportable ? .polloGreen : UIColor.white.withAlphaComponent(0.9)
         exportButton.setTitleColor(titleColor, for: .normal)
         exportButton.backgroundColor = backgroundColor
         exportButton.layer.borderColor = borderColor.cgColor

--- a/Pollo/Views/GroupControls/ExportButtonCell.swift
+++ b/Pollo/Views/GroupControls/ExportButtonCell.swift
@@ -49,7 +49,7 @@ class ExportButtonCell: UICollectionViewCell {
     }
 
     func configure(for isExportable: Bool) {
-        let titleColor: UIColor = isExportable ? .white : .blueyGrey
+        let titleColor: UIColor = isExportable ? .white : .blueGrey
         let backgroundColor: UIColor = isExportable ? .polloGreen : .clear
         let borderColor: UIColor = isExportable ? .polloGreen : UIColor.white.withAlphaComponent(0.9)
         exportButton.setTitleColor(titleColor, for: .normal)

--- a/Pollo/Views/GroupControls/PollsDateAttendanceCell.swift
+++ b/Pollo/Views/GroupControls/PollsDateAttendanceCell.swift
@@ -37,7 +37,7 @@ class PollsDateAttendanceCell: UICollectionViewCell {
     // MARK: - Layout
     func setupViews() {
         containerView = UIView()
-        containerView.backgroundColor = .darkgray
+        containerView.backgroundColor = .darkGrey
         containerView.layer.cornerRadius = contentViewCornerRadius
         containerView.clipsToBounds = true
         contentView.addSubview(containerView)

--- a/Pollo/Views/GroupControls/PollsDateAttendanceCell.swift
+++ b/Pollo/Views/GroupControls/PollsDateAttendanceCell.swift
@@ -37,7 +37,7 @@ class PollsDateAttendanceCell: UICollectionViewCell {
     // MARK: - Layout
     func setupViews() {
         containerView = UIView()
-        containerView.backgroundColor = .clickerGrey10
+        containerView.backgroundColor = .darkgray
         containerView.layer.cornerRadius = contentViewCornerRadius
         containerView.clipsToBounds = true
         contentView.addSubview(containerView)

--- a/Pollo/Views/GroupControls/SettingCell.swift
+++ b/Pollo/Views/GroupControls/SettingCell.swift
@@ -37,7 +37,7 @@ class SettingCell: UICollectionViewCell {
         layer.cornerRadius = 5
         layer.masksToBounds = true
         
-        backgroundColor = .darkgray
+        backgroundColor = .darkGrey
         setupViews()
         setupConstraints()
     }

--- a/Pollo/Views/GroupControls/SettingCell.swift
+++ b/Pollo/Views/GroupControls/SettingCell.swift
@@ -37,7 +37,7 @@ class SettingCell: UICollectionViewCell {
         layer.cornerRadius = 5
         layer.masksToBounds = true
         
-        backgroundColor = .clickerGrey10
+        backgroundColor = .darkgray
         setupViews()
         setupConstraints()
     }
@@ -63,7 +63,7 @@ class SettingCell: UICollectionViewCell {
         toggle = UISwitch()
         toggle.thumbTintColor = .white
         toggle.tintColor = .white
-        toggle.onTintColor = .clickerGreen0
+        toggle.onTintColor = .polloGreen
         toggle.isEnabled = true
         toggle.addTarget(self, action: #selector(toggleSwitched), for: .valueChanged)
         contentView.addSubview(toggle)

--- a/Pollo/Views/GroupControls/ViewAllCell.swift
+++ b/Pollo/Views/GroupControls/ViewAllCell.swift
@@ -22,7 +22,7 @@ class ViewAllCell: UICollectionViewCell {
 
         viewAllLabel = UILabel()
         viewAllLabel.text = viewAllText
-        viewAllLabel.textColor = .clickerGreen0
+        viewAllLabel.textColor = .polloGreen
         viewAllLabel.font = ._16MediumFont
         contentView.addSubview(viewAllLabel)
 

--- a/Pollo/Views/HomeScreen/Polls/PollPreviewCell.swift
+++ b/Pollo/Views/HomeScreen/Polls/PollPreviewCell.swift
@@ -67,11 +67,11 @@ class PollPreviewCell: UICollectionViewCell {
     
         descriptionLabel = UILabel()
         descriptionLabel.font = ._16MediumFont
-        descriptionLabel.textColor = .clickerGrey2
+        descriptionLabel.textColor = .blueyGrey
         contentView.addSubview(descriptionLabel)
         
         liveCircleView = UIView()
-        liveCircleView.backgroundColor = .clickerGreen0
+        liveCircleView.backgroundColor = .polloGreen
         liveCircleView.layer.cornerRadius = liveCircleViewLength / 2.0
         liveCircleView.isHidden = true
         contentView.addSubview(liveCircleView)
@@ -79,7 +79,7 @@ class PollPreviewCell: UICollectionViewCell {
         liveLabel = UILabel()
         liveLabel.text = liveLabelText
         liveLabel.font = UIFont._16SemiboldFont
-        liveLabel.textColor = .clickerGreen0
+        liveLabel.textColor = .polloGreen
         liveLabel.isHidden = true
         contentView.addSubview(liveLabel)
         

--- a/Pollo/Views/HomeScreen/Polls/PollPreviewCell.swift
+++ b/Pollo/Views/HomeScreen/Polls/PollPreviewCell.swift
@@ -67,7 +67,7 @@ class PollPreviewCell: UICollectionViewCell {
     
         descriptionLabel = UILabel()
         descriptionLabel.font = ._16MediumFont
-        descriptionLabel.textColor = .blueyGrey
+        descriptionLabel.textColor = .blueGrey
         contentView.addSubview(descriptionLabel)
         
         liveCircleView = UIView()

--- a/Pollo/Views/MultipleChoice/AddMoreOptionCell.swift
+++ b/Pollo/Views/MultipleChoice/AddMoreOptionCell.swift
@@ -56,14 +56,14 @@ class AddMoreOptionCell: UICollectionViewCell {
         
         plusLabel = UILabel()
         plusLabel.text = "+"
-        plusLabel.textColor = .clickerGrey2
+        plusLabel.textColor = .blueyGrey
         plusLabel.textAlignment = .center
         plusLabel.font = ._20MediumFont
         contentView.addSubview(plusLabel)
         
         addMoreLabel = UILabel()
         addMoreLabel.text = "Add Option"
-        addMoreLabel.textColor = .clickerGrey2
+        addMoreLabel.textColor = .blueyGrey
         addMoreLabel.font = ._16RegularFont
         contentView.addSubview(addMoreLabel)
     }

--- a/Pollo/Views/MultipleChoice/AddMoreOptionCell.swift
+++ b/Pollo/Views/MultipleChoice/AddMoreOptionCell.swift
@@ -56,14 +56,14 @@ class AddMoreOptionCell: UICollectionViewCell {
         
         plusLabel = UILabel()
         plusLabel.text = "+"
-        plusLabel.textColor = .blueyGrey
+        plusLabel.textColor = .blueGrey
         plusLabel.textAlignment = .center
         plusLabel.font = ._20MediumFont
         contentView.addSubview(plusLabel)
         
         addMoreLabel = UILabel()
         addMoreLabel.text = "Add Option"
-        addMoreLabel.textColor = .blueyGrey
+        addMoreLabel.textColor = .blueGrey
         addMoreLabel.font = ._16RegularFont
         contentView.addSubview(addMoreLabel)
     }

--- a/Pollo/Views/MultipleChoice/CreateMCOptionCell.swift
+++ b/Pollo/Views/MultipleChoice/CreateMCOptionCell.swift
@@ -119,7 +119,7 @@ class CreateMCOptionCell: UICollectionViewCell, UITextFieldDelegate {
             self.isCorrect = isCorrect
             isCorrectButton.setImage(isCorrect ? filledCircleImage : unfilledCircleImage, for: .normal)
             let choiceTag = intToMCOption(index)
-            addOptionTextField.attributedPlaceholder = NSAttributedString(string: "Option \(choiceTag)", attributes: [NSAttributedString.Key.foregroundColor: UIColor.clickerGrey2, NSAttributedString.Key.font: UIFont._16RegularFont])
+            addOptionTextField.attributedPlaceholder = NSAttributedString(string: "Option \(choiceTag)", attributes: [NSAttributedString.Key.foregroundColor: UIColor.blueyGrey, NSAttributedString.Key.font: UIFont._16RegularFont])
             addOptionTextField.text = option
         default:
             return

--- a/Pollo/Views/MultipleChoice/CreateMCOptionCell.swift
+++ b/Pollo/Views/MultipleChoice/CreateMCOptionCell.swift
@@ -119,7 +119,7 @@ class CreateMCOptionCell: UICollectionViewCell, UITextFieldDelegate {
             self.isCorrect = isCorrect
             isCorrectButton.setImage(isCorrect ? filledCircleImage : unfilledCircleImage, for: .normal)
             let choiceTag = intToMCOption(index)
-            addOptionTextField.attributedPlaceholder = NSAttributedString(string: "Option \(choiceTag)", attributes: [NSAttributedString.Key.foregroundColor: UIColor.blueyGrey, NSAttributedString.Key.font: UIFont._16RegularFont])
+            addOptionTextField.attributedPlaceholder = NSAttributedString(string: "Option \(choiceTag)", attributes: [NSAttributedString.Key.foregroundColor: UIColor.blueGrey, NSAttributedString.Key.font: UIFont._16RegularFont])
             addOptionTextField.text = option
         default:
             return

--- a/Pollo/Views/NameView.swift
+++ b/Pollo/Views/NameView.swift
@@ -43,7 +43,7 @@ class NameView: UIView, UITextFieldDelegate {
         addSubview(blurEffectView)
 
         titleField = UITextField()
-        titleField.attributedPlaceholder = NSAttributedString(string: "Give your group a name...", attributes: [NSAttributedString.Key.foregroundColor: UIColor.blueyGrey, NSAttributedString.Key.font: UIFont._24MediumFont])
+        titleField.attributedPlaceholder = NSAttributedString(string: "Give your group a name...", attributes: [NSAttributedString.Key.foregroundColor: UIColor.blueGrey, NSAttributedString.Key.font: UIFont._24MediumFont])
         if session.code != session.name {
             titleField.text = session.name
         }

--- a/Pollo/Views/NameView.swift
+++ b/Pollo/Views/NameView.swift
@@ -43,12 +43,12 @@ class NameView: UIView, UITextFieldDelegate {
         addSubview(blurEffectView)
 
         titleField = UITextField()
-        titleField.attributedPlaceholder = NSAttributedString(string: "Give your group a name...", attributes: [NSAttributedString.Key.foregroundColor: UIColor.clickerGrey2, NSAttributedString.Key.font: UIFont._24MediumFont])
+        titleField.attributedPlaceholder = NSAttributedString(string: "Give your group a name...", attributes: [NSAttributedString.Key.foregroundColor: UIColor.blueyGrey, NSAttributedString.Key.font: UIFont._24MediumFont])
         if session.code != session.name {
             titleField.text = session.name
         }
         titleField.font = ._24MediumFont
-        titleField.textColor = .clickerWhite
+        titleField.textColor = .offWhite
         titleField.textAlignment = .center
         titleField.delegate = self
         titleField.becomeFirstResponder()

--- a/Pollo/Views/OptionsView.swift
+++ b/Pollo/Views/OptionsView.swift
@@ -96,7 +96,7 @@ class OptionsView: UIView, UICollectionViewDataSource, UICollectionViewDelegate,
         isJoined = indexPath.row == 0 
         sliderBarDelegate?.changeNewGroupButton(status: isJoined)
         let unselectedCell = collectionView.cellForItem(at: unselectedIndexPath) as! QuestionOptionCell
-        unselectedCell.optionLabel.textColor = .clickerGrey2
+        unselectedCell.optionLabel.textColor = .blueyGrey
     }
     
     required init?(coder _: NSCoder) {
@@ -108,7 +108,7 @@ class QuestionOptionCell: UICollectionViewCell {
     
     override var isSelected: Bool {
         didSet {
-            optionLabel.textColor = isSelected ? .black : .clickerGrey2
+            optionLabel.textColor = isSelected ? .black : .blueyGrey
         }
     }
     
@@ -117,7 +117,7 @@ class QuestionOptionCell: UICollectionViewCell {
         label.textAlignment = .center
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
-        label.textColor = .clickerGrey2
+        label.textColor = .blueyGrey
         label.font = UIFont._18MediumFont
         return label
     }()

--- a/Pollo/Views/OptionsView.swift
+++ b/Pollo/Views/OptionsView.swift
@@ -96,7 +96,7 @@ class OptionsView: UIView, UICollectionViewDataSource, UICollectionViewDelegate,
         isJoined = indexPath.row == 0 
         sliderBarDelegate?.changeNewGroupButton(status: isJoined)
         let unselectedCell = collectionView.cellForItem(at: unselectedIndexPath) as! QuestionOptionCell
-        unselectedCell.optionLabel.textColor = .blueyGrey
+        unselectedCell.optionLabel.textColor = .blueGrey
     }
     
     required init?(coder _: NSCoder) {
@@ -108,7 +108,7 @@ class QuestionOptionCell: UICollectionViewCell {
     
     override var isSelected: Bool {
         didSet {
-            optionLabel.textColor = isSelected ? .black : .blueyGrey
+            optionLabel.textColor = isSelected ? .black : .blueGrey
         }
     }
     
@@ -117,7 +117,7 @@ class QuestionOptionCell: UICollectionViewCell {
         label.textAlignment = .center
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
-        label.textColor = .blueyGrey
+        label.textColor = .blueGrey
         label.font = UIFont._18MediumFont
         return label
     }()

--- a/Pollo/Views/PollBuilder/AskQuestionCell.swift
+++ b/Pollo/Views/PollBuilder/AskQuestionCell.swift
@@ -46,7 +46,7 @@ class AskQuestionCell: UICollectionViewCell {
         contentView.addSubview(questionTextView)
         
         charCountLabel = UILabel()
-        charCountLabel.textColor = .blueyGrey
+        charCountLabel.textColor = .blueGrey
         charCountLabel.font = ._12RegularFont
         contentView.addSubview(charCountLabel)
 
@@ -63,7 +63,7 @@ class AskQuestionCell: UICollectionViewCell {
             updateQuestionTextViewHeight()
         } else {
             questionTextView.text = questionLabelPlaceholder
-            questionTextView.textColor = .blueyGrey
+            questionTextView.textColor = .blueGrey
             charCountLabel.text = nil
         }
     }
@@ -110,7 +110,7 @@ extension AskQuestionCell: UITextViewDelegate {
     }
     
     func textViewDidBeginEditing(_ textView: UITextView) {
-        if textView.textColor == .blueyGrey {
+        if textView.textColor == .blueGrey {
             textView.text = nil
             textView.textColor = .black
         }

--- a/Pollo/Views/PollBuilder/AskQuestionCell.swift
+++ b/Pollo/Views/PollBuilder/AskQuestionCell.swift
@@ -35,18 +35,18 @@ class AskQuestionCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        contentView.backgroundColor = .clickerWhite
+        contentView.backgroundColor = .offWhite
         
         questionTextView = UITextView()
         questionTextView.delegate = self
         questionTextView.font = ._18RegularFont
-        questionTextView.backgroundColor = .clickerWhite
+        questionTextView.backgroundColor = .offWhite
         questionTextView.returnKeyType = .done
         questionTextView.isScrollEnabled = false
         contentView.addSubview(questionTextView)
         
         charCountLabel = UILabel()
-        charCountLabel.textColor = .clickerGrey2
+        charCountLabel.textColor = .blueyGrey
         charCountLabel.font = ._12RegularFont
         contentView.addSubview(charCountLabel)
 
@@ -63,7 +63,7 @@ class AskQuestionCell: UICollectionViewCell {
             updateQuestionTextViewHeight()
         } else {
             questionTextView.text = questionLabelPlaceholder
-            questionTextView.textColor = .clickerGrey2
+            questionTextView.textColor = .blueyGrey
             charCountLabel.text = nil
         }
     }
@@ -110,7 +110,7 @@ extension AskQuestionCell: UITextViewDelegate {
     }
     
     func textViewDidBeginEditing(_ textView: UITextView) {
-        if textView.textColor == .clickerGrey2 {
+        if textView.textColor == .blueyGrey {
             textView.text = nil
             textView.textColor = .black
         }

--- a/Pollo/Views/PollBuilder/FRPollBuilderView.swift
+++ b/Pollo/Views/PollBuilder/FRPollBuilderView.swift
@@ -75,7 +75,7 @@ class FRPollBuilderView: UIView {
     func setupViews() {
         let layout = UICollectionViewFlowLayout()
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        collectionView.backgroundColor = .clickerWhite
+        collectionView.backgroundColor = .offWhite
         collectionView.showsVerticalScrollIndicator = false
         addSubview(collectionView)
 

--- a/Pollo/Views/PollBuilder/MCPollBuilderView.swift
+++ b/Pollo/Views/PollBuilder/MCPollBuilderView.swift
@@ -113,7 +113,7 @@ class MCPollBuilderView: UIView {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        collectionView.backgroundColor = .clickerWhite
+        collectionView.backgroundColor = .offWhite
         collectionView.showsVerticalScrollIndicator = false
         collectionView.bounces = true
         addSubview(collectionView)

--- a/Pollo/Views/Settings/SettingsInfoCell.swift
+++ b/Pollo/Views/Settings/SettingsInfoCell.swift
@@ -33,7 +33,7 @@ class SettingsInfoCell: UICollectionViewCell {
         
         descriptionView = UILabel()
         descriptionView.font = UIFont._16MediumFont
-        descriptionView.textColor = UIColor.clickerGrey2
+        descriptionView.textColor = UIColor.blueyGrey
         descriptionView.textAlignment = .left
         descriptionView.numberOfLines = 0
         contentView.addSubview(descriptionView)

--- a/Pollo/Views/Settings/SettingsInfoCell.swift
+++ b/Pollo/Views/Settings/SettingsInfoCell.swift
@@ -33,7 +33,7 @@ class SettingsInfoCell: UICollectionViewCell {
         
         descriptionView = UILabel()
         descriptionView.font = UIFont._16MediumFont
-        descriptionView.textColor = UIColor.blueyGrey
+        descriptionView.textColor = UIColor.blueGrey
         descriptionView.textAlignment = .left
         descriptionView.numberOfLines = 0
         contentView.addSubview(descriptionView)

--- a/Pollo/Views/Settings/SettingsLinkCell.swift
+++ b/Pollo/Views/Settings/SettingsLinkCell.swift
@@ -26,7 +26,7 @@ class SettingsLinkCell: UICollectionViewCell {
     
     func setupViews() {
         linkButton = UIButton()
-        linkButton.setTitleColor(UIColor.clickerGreen0, for: .normal)
+        linkButton.setTitleColor(UIColor.polloGreen, for: .normal)
         linkButton.titleLabel?.textAlignment = .left
         linkButton.titleLabel?.font = UIFont._18MediumFont
         linkButton.contentHorizontalAlignment = .left

--- a/Pollo/Views/Settings/SettingsLogOutButtonCell.swift
+++ b/Pollo/Views/Settings/SettingsLogOutButtonCell.swift
@@ -32,7 +32,7 @@ class SettingsLogOutButtonCell: UICollectionViewCell {
     
     func setupViews() {
         logOutButton = UIButton()
-        logOutButton.setTitleColor(UIColor.clickerGreen0, for: .normal)
+        logOutButton.setTitleColor(UIColor.polloGreen, for: .normal)
         logOutButton.titleLabel?.textAlignment = .left
         logOutButton.titleLabel?.font = UIFont._18MediumFont
         logOutButton.contentHorizontalAlignment = .left


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

This PR updates the colors in the `UIColor` extension to reflect the most recent designs on Zeplin. It also removes colors that are not used anywhere in the app anymore.

## Changes Made

I added new static constants to the `UIColor` extension so that the new colors can be used anywhere in the codebase. I then changed all use cases of the old colors to the new colors.

## Test Coverage

I ran the app on the Xcode simulator to verify that the new colors I added in the extension look like those in the designs on Zeplin.

## Related PRs or Issues

https://github.com/cuappdev/pollo-ios/issues/307