### PR TITLE
Fix Result Bars

### DIFF
--- a/Pollo/ViewControllers/PollsViewController+Extension.swift
+++ b/Pollo/ViewControllers/PollsViewController+Extension.swift
@@ -84,7 +84,7 @@ extension PollsViewController: PollsCellDelegate {
                             pollsDateArray[index].polls.append(contentsOf: response.polls)
                         } else {
                             response.polls.forEach { poll in
-                                let polls = [Poll(text: poll.text, answerChoices: poll.answerChoices, type: poll.type, userAnswers: poll.userAnswers, state: poll.state)]
+                                let polls = [Poll(text: poll.text, answerChoices: poll.answerChoices, type: poll.type, correctAnswer: poll.correctAnswer, userAnswers: poll.userAnswers, state: poll.state)]
                                 pollsDateArray.append(PollsDateModel(date: response.date, polls: polls))
                             }
                         }

--- a/Pollo/ViewControllers/PollsViewController.swift
+++ b/Pollo/ViewControllers/PollsViewController.swift
@@ -414,7 +414,7 @@ class PollsViewController: UIViewController {
                             pollsDateArray[index].polls.append(contentsOf: response.polls)
                         } else {
                             response.polls.forEach { poll in
-                                let polls = [Poll(text: poll.text, answerChoices: poll.answerChoices, type: poll.type, userAnswers: poll.userAnswers, state: poll.state)]
+                                let polls = [Poll(text: poll.text, answerChoices: poll.answerChoices, type: poll.type, correctAnswer: poll.correctAnswer, userAnswers: poll.userAnswers, state: poll.state)]
                                 pollsDateArray.append(PollsDateModel(date: response.date, polls: polls))
                             }
                         }

--- a/Pollo/Views/Cards/CardCell.swift
+++ b/Pollo/Views/Cards/CardCell.swift
@@ -131,10 +131,14 @@ class CardCell: UICollectionViewCell {
         timerLabel.isHidden = !(poll.state == .live) || isMember
         if poll.state == .live {
             questionButton.setTitle(endPollText, for: .normal)
+            questionButton.setTitleColor(.white, for: .normal)
+            questionButton.layer.borderColor = UIColor.white.cgColor
             setTimerText()
             runTimer()
         } else if poll.state == .ended {
             questionButton.setTitle(shareResultsText, for: .normal)
+            questionButton.setTitleColor(.white, for: .normal)
+            questionButton.layer.borderColor = UIColor.white.cgColor
         } else if poll.state == .shared {
             questionButton.setTitle(resultsSharedText, for: .normal)
             questionButton.setTitleColor(.blueGrey, for: .normal)

--- a/Pollo/Views/Cards/MCResultCell.swift
+++ b/Pollo/Views/Cards/MCResultCell.swift
@@ -31,13 +31,14 @@ class MCResultCell: UICollectionViewCell {
     
     // MARK: - Constants
     let checkImageName = "correctanswer"
-    let containerViewBorderWidth: CGFloat = 0.6
+    let containerViewBorderWidth: CGFloat = 0.3
     let containerViewCornerRadius: CGFloat = 8
     let containerViewHeight: CGFloat = 46
     let containerViewTopPadding: CGFloat = 8
     let correctImageName = "correct"
     let dotViewBorderWidth: CGFloat = 2
     let dotViewLength: CGFloat = 23
+    let highlightViewBorderWidth: CGFloat = 0.6
     let horizontalPadding: CGFloat = 12
     let incorrectImageName = "incorrect"
     let labelFontSize: CGFloat = 13
@@ -57,6 +58,8 @@ class MCResultCell: UICollectionViewCell {
     func setupViews() {
         containerView.layer.cornerRadius = containerViewCornerRadius
         containerView.clipsToBounds = true
+        containerView.layer.borderColor = UIColor.mediumGrey2.cgColor
+        containerView.layer.borderWidth = containerViewBorderWidth
         contentView.addSubview(containerView)
         
         optionLabel.font = ._14MediumFont
@@ -84,6 +87,9 @@ class MCResultCell: UICollectionViewCell {
         
         contentView.addSubview(selectedImageView)
 
+        highlightView.layer.cornerRadius = containerViewCornerRadius
+        highlightView.clipsToBounds = true
+        highlightView.layer.borderWidth = highlightViewBorderWidth
         containerView.addSubview(highlightView)
         containerView.sendSubviewToBack(highlightView)
     }
@@ -148,8 +154,11 @@ class MCResultCell: UICollectionViewCell {
         }
 
         highlightView.snp.makeConstraints { make in
-            make.leading.top.bottom.trailing.equalToSuperview()
+            make.leading.top.bottom.equalToSuperview()
+            let highlightViewMaxWidth = Float(contentView.bounds.width - horizontalPadding * 2)
+            highlightViewWidthConstraint = make.width.equalTo(0).offset(highlightViewMaxWidth * percentSelected).constraint
         }
+
         super.updateConstraints()
     }
     
@@ -160,21 +169,23 @@ class MCResultCell: UICollectionViewCell {
         numSelectedLabel.text = "\(Int(percentSelected * 100))%"
         self.correctAnswer = correctAnswer
         self.userRole = userRole
+        let answer = intToMCOption(resultModel.choiceIndex)
         switch userRole {
         case .admin:
-            containerView.backgroundColor = .lightGrey
-            highlightView.backgroundColor = correctAnswer == resultModel.option ? .lightGreen : .lightGrey
+            containerView.backgroundColor = correctAnswer == answer ? .lightGreen : .lightGrey
+            highlightView.isHidden = true
             numSelectedLabel.isHidden = false
             dotView.isHidden = true
             optionLabel.textColor = .black
         case .member:
+            containerView.backgroundColor = .clear
+            containerView.layer.borderColor = UIColor.coolGrey.cgColor
             optionLabel.textColor = .mediumGrey
             numSelectedLabel.isHidden = true
             dotView.isHidden = false
             let isSelected = resultModel.isSelected
             selectedDotView.isHidden = !isSelected
             selectedImageView.isHidden = selectedDotView.isHidden
-            let answer = intToMCOption(resultModel.choiceIndex)
             if let correctAnswer = correctAnswer, !correctAnswer.isEmpty {
                 if answer == correctAnswer {
                     if isSelected {
@@ -182,8 +193,8 @@ class MCResultCell: UICollectionViewCell {
                         selectedImageView.image = UIImage(named: correctImageName)
                     }
                     showCorrectAnswer = true
-                    highlightView.backgroundColor = isSelected ? .lightGreen : .lightGrey
-                    highlightView.layer.borderColor = isSelected ? UIColor.polloGreen.cgColor : UIColor.coolGrey.cgColor
+                    highlightView.backgroundColor = .lightGreen
+                    highlightView.layer.borderColor = UIColor.polloGreen.cgColor
                 } else {
                     if isSelected {
                         selectedDotView.backgroundColor = .clear
@@ -208,7 +219,6 @@ class MCResultCell: UICollectionViewCell {
         optionLabel.text = resultModel.option
         percentSelected = resultModel.percentSelected
         numSelectedLabel.text = "\(Int(percentSelected * 100))%"
-        highlightView.backgroundColor = correctAnswer == resultModel.option ? .lightGreen : .lightGrey
     }
     
     override func prepareForReuse() {

--- a/Pollo/Views/Cards/MCResultCell.swift
+++ b/Pollo/Views/Cards/MCResultCell.swift
@@ -153,8 +153,7 @@ class MCResultCell: UICollectionViewCell {
 
         highlightView.snp.makeConstraints { make in
             make.leading.top.bottom.equalToSuperview()
-            let highlightViewMaxWidth = Float(contentView.bounds.width - horizontalPadding * 2)
-            highlightViewWidthConstraint = make.width.equalTo(0).offset(highlightViewMaxWidth * percentSelected).constraint
+            make.width.equalToSuperview().multipliedBy(percentSelected)
         }
 
         super.updateConstraints()

--- a/Pollo/Views/Cards/MCResultCell.swift
+++ b/Pollo/Views/Cards/MCResultCell.swift
@@ -32,13 +32,14 @@ class MCResultCell: UICollectionViewCell {
     // MARK: - Constants
     let checkImageName = "correctanswer"
     let containerViewBorderWidth: CGFloat = 0.3
-    let containerViewCornerRadius: CGFloat = 8
+    let containerViewCornerRadius: CGFloat = 3
     let containerViewHeight: CGFloat = 46
     let containerViewTopPadding: CGFloat = 8
     let correctImageName = "correct"
     let dotViewBorderWidth: CGFloat = 2
     let dotViewLength: CGFloat = 23
     let highlightViewBorderWidth: CGFloat = 0.6
+    let highlightViewCornerRadius: CGFloat = 8
     let horizontalPadding: CGFloat = 12
     let incorrectImageName = "incorrect"
     let labelFontSize: CGFloat = 13
@@ -56,11 +57,14 @@ class MCResultCell: UICollectionViewCell {
     
     // MARK: - Layout
     func setupViews() {
-        containerView.layer.cornerRadius = containerViewCornerRadius
         containerView.clipsToBounds = true
         containerView.layer.borderColor = UIColor.mediumGrey2.cgColor
-        containerView.layer.borderWidth = containerViewBorderWidth
         contentView.addSubview(containerView)
+
+        highlightView.layer.cornerRadius = highlightViewCornerRadius
+        highlightView.clipsToBounds = true
+        highlightView.layer.borderWidth = highlightViewBorderWidth
+        containerView.addSubview(highlightView)
         
         optionLabel.font = ._14MediumFont
         optionLabel.backgroundColor = .clear
@@ -86,12 +90,6 @@ class MCResultCell: UICollectionViewCell {
         contentView.addSubview(selectedDotView)
         
         contentView.addSubview(selectedImageView)
-
-        highlightView.layer.cornerRadius = containerViewCornerRadius
-        highlightView.clipsToBounds = true
-        highlightView.layer.borderWidth = highlightViewBorderWidth
-        containerView.addSubview(highlightView)
-        containerView.sendSubviewToBack(highlightView)
     }
     
     override func updateConstraints() {
@@ -173,13 +171,16 @@ class MCResultCell: UICollectionViewCell {
         switch userRole {
         case .admin:
             containerView.backgroundColor = correctAnswer == answer ? .lightGreen : .lightGrey
+            containerView.layer.borderWidth = containerViewBorderWidth
+            containerView.layer.cornerRadius = containerViewCornerRadius
             highlightView.isHidden = true
             numSelectedLabel.isHidden = false
             dotView.isHidden = true
             optionLabel.textColor = .black
         case .member:
             containerView.backgroundColor = .clear
-            containerView.layer.borderColor = UIColor.coolGrey.cgColor
+            containerView.layer.borderWidth = highlightViewBorderWidth
+            containerView.layer.cornerRadius = highlightViewCornerRadius
             optionLabel.textColor = .mediumGrey
             numSelectedLabel.isHidden = true
             dotView.isHidden = false


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->
Update `containerView` and `highlightView` in` MCResultCell` to reflect new designs. Additionally this PR solves the bug where an admin does not see the correct answer they set in `Card Cell` and the bug where if a student leaves and returns their submission if correct or incorrect is no longer reflects that. Lastly, the end poll button color bug has been fixed.


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
Changed varying attributes to the respective UIElements depending on whether `UserRole` is `member` or `admin`. Lastly `correctAnswer` was added to the response data for `getSortedPolls` to solve the bugs.

## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
Compared changes to Zeplin files and tested to ensure the bugs no longer persisted.

## Screenshots

<!-- This could include of screenshots of the new feature / proof that the changes work. -->

<details>

  <summary>Student Side</summary>


  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->
  ![Simulator Screen Shot - iPhone Xʀ - 2019-11-20 at 22 30 51](https://user-images.githubusercontent.com/45302979/69302034-41a5f400-0be6-11ea-951c-63ab6ee4b283.png)

</details>

<details>

  <summary>Admin Side</summary>


  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->
![Simulator Screen Shot - iPhone Xʀ - 2019-11-20 at 22 31 00](https://user-images.githubusercontent.com/45302979/69302057-56828780-0be6-11ea-8c19-1d7668fbef27.png)


</details>