### PR TITLE
Removed upvoting

### DIFF
--- a/Pollo/SectionControllers/CardSectionControllers/PollOptionsSectionController.swift
+++ b/Pollo/SectionControllers/CardSectionControllers/PollOptionsSectionController.swift
@@ -13,7 +13,6 @@ protocol PollOptionsSectionControllerDelegate {
     var userRole: UserRole { get }
     
     func pollOptionsSectionControllerDidSubmitChoice(sectionController: PollOptionsSectionController, choice: String, index: Int?)
-    func pollOptionsSectionControllerDidUpvote(sectionController: PollOptionsSectionController, text: String)
     
 }
 
@@ -65,10 +64,6 @@ extension PollOptionsSectionController: PollOptionsCellDelegate {
 
     func pollOptionsCellDidSubmitChoice(choice: String, index: Int) {
         delegate.pollOptionsSectionControllerDidSubmitChoice(sectionController: self, choice: choice, index: index)
-    }
-
-    func pollOptionsCellDidUpvote(for text: String) {
-        delegate.pollOptionsSectionControllerDidUpvote(sectionController: self, text: text)
     }
     
 }

--- a/Pollo/SectionControllers/PollSectionController.swift
+++ b/Pollo/SectionControllers/PollSectionController.swift
@@ -13,7 +13,6 @@ protocol PollSectionControllerDelegate: class {
     
     var role: UserRole { get }
 
-    func pollSectionControllerDidUpvote(pollChoice: PollChoice)
     func pollSectionControllerDidEditPoll(sectionController: PollSectionController, poll: Poll)
     func pollSectionControllerDidEndPoll(sectionController: PollSectionController, poll: Poll)
     func pollSectionControllerDidShareResultsForPoll(sectionController: PollSectionController, poll: Poll)
@@ -68,10 +67,6 @@ extension PollSectionController: CardCellDelegate {
             poll.updateSelected(mcChoice: intToMCOption(index))
         }
         delegate.pollSectionControllerDidSubmitChoiceForPoll(sectionController: self, choice: choice, poll: poll)
-    }
-
-    func cardCellDidUpvote(cardCell: CardCell, pollChoice: PollChoice) {
-        delegate.pollSectionControllerDidUpvote(pollChoice: pollChoice)
     }
     
     func cardCellDidEndPoll(cardCell: CardCell, poll: Poll) {

--- a/Pollo/Supporting/Constants.swift
+++ b/Pollo/Supporting/Constants.swift
@@ -46,7 +46,6 @@ struct Routes {
     static let serverShare = "server/poll/results"
     static let serverStart = "server/poll/start"
     static let serverTally = "server/poll/tally"
-    static let serverUpvote = "server/poll/upvote"
     static let userDelete = "user/poll/delete"
     static let userDeleteLive = "user/poll/delete/live"
     static let userEnd = "user/poll/end"
@@ -92,7 +91,6 @@ struct ParserKeys {
     static let textKey = "text"
     static let typeKey = "type"
     static let updatedAtKey = "updatedAt"
-    static let upvotesKey = "upvotes"
 }
 
 struct RequestKeys {

--- a/Pollo/ViewControllers/CardController+Extension.swift
+++ b/Pollo/ViewControllers/CardController+Extension.swift
@@ -65,11 +65,6 @@ extension CardController: PollSectionControllerDelegate {
             emitAnswer(pollChoice: pollChoice, message: Routes.serverAnswer)
         }
     }
-
-    func pollSectionControllerDidUpvote(pollChoice: PollChoice) {
-        guard let pollChoiceDict = pollChoice.dictionary else { return }
-        socket.socket.emit(Routes.serverUpvote, pollChoiceDict)
-    }
     
     func pollSectionControllerDidEndPoll(sectionController: PollSectionController, poll: Poll) {
         createPollButton.isUserInteractionEnabled = true

--- a/Pollo/Views/Cards/CardCell.swift
+++ b/Pollo/Views/Cards/CardCell.swift
@@ -18,8 +18,7 @@ protocol CardCellDelegate: class {
     func cardCellDidEditPoll(cardCell: CardCell, poll: Poll)
     func cardCellDidEndPoll(cardCell: CardCell, poll: Poll)
     func cardCellDidShareResults(cardCell: CardCell, poll: Poll)
-    func cardCellDidSubmitChoice(cardCell: CardCell, choice: String, index: Int?) 
-    func cardCellDidUpvote(cardCell: CardCell, pollChoice: PollChoice)
+    func cardCellDidSubmitChoice(cardCell: CardCell, choice: String, index: Int?)
 
 }
 
@@ -284,11 +283,6 @@ extension CardCell: PollOptionsSectionControllerDelegate {
         miscellaneousModel = PollMiscellaneousModel(questionType: miscellaneousModel.questionType, pollState: miscellaneousModel.pollState, totalVotes: miscellaneousModel.totalVotes, userRole: miscellaneousModel.userRole, didSubmitChoice: true)
         adapter.performUpdates(animated: false, completion: nil)
         delegate.cardCellDidSubmitChoice(cardCell: self, choice: choice, index: index)
-    }
-
-    func pollOptionsSectionControllerDidUpvote(sectionController: PollOptionsSectionController, text: String) {
-        let pollChoice = PollChoice(text: text)
-        delegate.cardCellDidUpvote(cardCell: self, pollChoice: pollChoice)
     }
     
 }

--- a/Pollo/Views/Cards/PollOptionsCell.swift
+++ b/Pollo/Views/Cards/PollOptionsCell.swift
@@ -14,7 +14,6 @@ protocol PollOptionsCellDelegate: class {
     var userRole: UserRole { get }
     
     func pollOptionsCellDidSubmitChoice(choice: String, index: Int)
-    func pollOptionsCellDidUpvote(for text: String)
     
 }
 


### PR DESCRIPTION

## Overview

This is the first part of API spec changes (#335), upvoting being the first thing removed.


## Changes Made

Removed upvoting delegates and socket routes.


## Test Coverage

Polling still works!


## Next Steps (delete if not applicable)

Later will look into refactoring PollResult and PollChoice to remove confusion between `letter` and `text`, which was remnant of Free Response functionality.


## Related PRs or Issues (delete if not applicable)

#335 
