### PR TITLE
[Fix live session edge case]

### DIFF
--- a/Pollo/ViewControllers/CardController+Extension.swift
+++ b/Pollo/ViewControllers/CardController+Extension.swift
@@ -385,6 +385,7 @@ extension CardController: SocketDelegate {
         switch pollsDateModel.polls[index].state {
         case .live:
             socket.socket.emit(Routes.serverDeleteLive)
+            session.isLive = false
             pollsDateModel.polls[index].state = .ended
             createPollButton.isUserInteractionEnabled = true
             createPollButton.isHidden = false


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

When deleting a live poll, the create poll button would disappear when returning to PollsDateView because the app was under the impression that I was still polling a live question. I just made sure that the poll would be set offline if it were deleted while live.

## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

Set `session.isLive` to false when deleting a live poll.

## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

Manual testing on the professor and student side to ensure this didn't create another bug.

## Next Steps

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->

Working on the bug I found while working on this - #357

## Related PRs or Issue

<!-- List related PRs against other branches/repositories. -->

#351


## Screenshots

<!-- This could include of screenshots of the new feature / proof that the changes work. -->

Pay attention to the + button on the upper right to see the differences
<details>
<summary>One question - before</summary>

![ezgif com-resize](https://user-images.githubusercontent.com/21962778/74386713-a9727200-4dc4-11ea-96da-b2914c472864.gif)
</details>
<details>
<summary> One question - after</summary>

![ezgif com-resize (2)](https://user-images.githubusercontent.com/21962778/74386901-2bfb3180-4dc5-11ea-9369-b64fda283577.gif)
</details>
<details>
<summary> Multiple questions - before</summary>

![ezgif com-resize (1)](https://user-images.githubusercontent.com/21962778/74386793-e5a5d280-4dc4-11ea-92b3-32866ea343a2.gif)
</details>
<details>
<summary> Multiple questions - after</summary>

![ezgif com-resize (3)](https://user-images.githubusercontent.com/21962778/74386994-6795fb80-4dc5-11ea-991d-bcd143fb0599.gif)
</details>