### PR TITLE
Fixed banner persistence issue

### DIFF
--- a/Pollo.xcodeproj/project.pbxproj
+++ b/Pollo.xcodeproj/project.pbxproj
@@ -1147,7 +1147,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				INFOPLIST_FILE = Pollo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1281,7 +1281,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				INFOPLIST_FILE = Pollo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1434,7 +1434,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				INFOPLIST_FILE = Pollo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1460,7 +1460,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				INFOPLIST_FILE = Pollo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;

--- a/Pollo/Extensions/UIViewController+Shared.swift
+++ b/Pollo/Extensions/UIViewController+Shared.swift
@@ -32,4 +32,24 @@ extension UIViewController {
         return true
     }
 
+    func add(_ child: UIViewController) {
+        addChild(child)
+        view.addSubview(child.view)
+        child.didMove(toParent: self)
+    }
+
+    func remove() {
+        guard parent != nil else {
+            return
+        }
+
+        willMove(toParent: nil)
+        view.removeFromSuperview()
+        removeFromParent()
+    }
+
+    func pop() {
+        
+    }
+
 }

--- a/Pollo/Supporting/BannerController.swift
+++ b/Pollo/Supporting/BannerController.swift
@@ -7,7 +7,168 @@
 //
 
 import Foundation
+import FutureNova
+import UIKit
 import NotificationBannerSwift
+
+protocol PollingViewControllerDelegate: class {
+    func pollsDateViewControllerWasPopped(for userRole: UserRole)
+}
+
+class PollingViewController: UIViewController {
+
+    // MARK: - View vars
+    var createPollButton: UIButton!
+    var navigationTitleView: NavigationTitleView!
+
+    var childNavController: UINavigationController!
+    var pollsDateViewController: PollsDateViewController!
+
+    var currentBanner: BaseNotificationBanner? {
+        didSet {
+            oldValue?.dismiss()
+            currentBanner?.show(bannerPosition: .bottom, on: self)
+        }
+    }
+
+    // MARK: - Data vars
+    private let networking: Networking = URLSession.shared.request
+    var pollsDateArray: [PollsDateModel]!
+    var session: Session!
+    var socket: Socket!
+    var userRole: UserRole!
+    weak var delegate: PollingViewControllerDelegate?
+
+    init(delegate: PollingViewControllerDelegate, pollsDateArray: [PollsDateModel], session: Session, userRole: UserRole) {
+        super.init(nibName: nil, bundle: nil)
+
+        self.delegate = delegate
+        self.pollsDateArray = pollsDateArray
+        self.session = session
+        self.userRole = userRole
+    }
+
+    // MARK: - View lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupNavBar()
+
+        pollsDateViewController = PollsDateViewController(pollsDateArray: [], session: session, userRole: .admin)
+        childNavController = UINavigationController(rootViewController: pollsDateViewController)
+        childNavController.setNavigationBarHidden(true, animated: false)
+        add(childNavController)
+//        add(pollsDateViewController)
+    }
+
+    func setupNavBar() {
+        navigationController?.setNavigationBarHidden(false, animated: false)
+        // REMOVE BOTTOM SHADOW
+        navigationController?.navigationBar.setBackgroundImage(UIImage(), for: UIBarMetrics.default)
+        navigationController?.navigationBar.shadowImage = UIImage()
+        let textHeight = navigationController?.navigationBar.frame.height ?? 0
+        navigationTitleView = getNavigationTitleView(primaryText: session.name, primaryTextHeight: textHeight, secondaryText: "Code: \(session.code)", secondaryTextHeight: textHeight, userRole: userRole, delegate: self)
+        self.navigationItem.titleView = navigationTitleView
+
+        let backImage = UIImage(named: "back")?.withRenderingMode(.alwaysOriginal)
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: backImage, style: .done, target: self, action: #selector(goBack))
+
+        if userRole == .admin {
+            createPollButton = UIButton()
+            createPollButton.isHidden = pollsDateArray.last?.polls.last?.state == .live
+            createPollButton.setImage(#imageLiteral(resourceName: "whiteCreatePoll"), for: .normal)
+            createPollButton.addTarget(self, action: #selector(createPollBtnPressed), for: .touchUpInside)
+            let createPollBarButton = UIBarButtonItem(customView: createPollButton)
+            self.navigationItem.rightBarButtonItems = [createPollBarButton]
+        }
+    }
+
+    // MARK: ACTIONS
+    @objc func createPollBtnPressed() {
+       // ok
+    }
+
+    @objc func goBack() {
+        if childNavController.popViewController(animated: true) == nil {
+            self.navigationController?.setNavigationBarHidden(true, animated: false)
+                    self.navigationController?.popViewController(animated: true)
+                    childNavController.remove()
+
+                    if pollsDateArray.isEmpty && session.name == session.code {
+                        deleteSession(with: session.id).observe { [weak self] result in
+                            guard let `self` = self else { return }
+                            DispatchQueue.main.async {
+                                switch result {
+                                case .value(let response):
+                                    if response.success {
+                                        self.delegate?.pollsDateViewControllerWasPopped(for: self.userRole)
+                                    } else {
+                                        let alertController = self.createAlert(title: "Error", message: "Failed to delete session. Try again!")
+                                        self.present(alertController, animated: true, completion: nil)
+                                    }
+                                case .error(let error):
+                                    print(error)
+                                    let alertController = self.createAlert(title: "Error", message: "Failed to delete session. Try again!")
+                                    self.present(alertController, animated: true, completion: nil)
+                                }
+                            }
+                        }
+                    } else {
+                        self.delegate?.pollsDateViewControllerWasPopped(for: self.userRole)
+                    }
+        }
+
+
+        // ok
+
+
+    }
+
+    func getMembers(with id: String) -> Future<Response<[GetMemberResponse]>> {
+        return networking(Endpoint.getMembers(with: id)).decode()
+    }
+
+    func deleteSession(with id: String) -> Future<DeleteResponse> {
+        return networking(Endpoint.deleteSession(with: id)).decode()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
+    }
+}
+
+extension PollingViewController: NavigationTitleViewDelegate {
+    func navigationTitleViewNavigationButtonTapped() {
+        guard userRole == .admin else { return }
+        let pollsDateAttendanceArray = pollsDateArray.map { PollsDateAttendanceModel(model: $0, isSelected: false) }
+        getMembers(with: session?.id ?? "").observe { [weak self] result in
+            guard let `self` = self else { return }
+            DispatchQueue.main.async {
+                switch result {
+                case .value(let response):
+                    let groupControlsVC = GroupControlsViewController(session: self.session, pollsDateAttendanceArray: pollsDateAttendanceArray, numMembers: response.data.count, delegate: self)
+                    self.navigationController?.pushViewController(groupControlsVC, animated: true)
+                case .error(let error):
+                    print(error)
+                    let alertController = self.createAlert(title: "Error", message: "Failed to load data. Try again!")
+                    self.present(alertController, animated: true, completion: nil)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - GroupControlsViewControllerDelegate
+extension PollingViewController: GroupControlsViewControllerDelegate {
+    func groupControlsViewControllerDidUpdateSession(_ session: Session) {
+        self.session = session
+    }
+
+
+}
 
 public class BannerController {
 

--- a/Pollo/Supporting/BannerController.swift
+++ b/Pollo/Supporting/BannerController.swift
@@ -177,6 +177,7 @@ public class BannerController {
     var currentBanner: BaseNotificationBanner?
 
     func show(_ banner: BaseNotificationBanner) {
+        banner.delegate = self
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             self.currentBanner?.dismiss()
@@ -192,4 +193,24 @@ public class BannerController {
             self.currentBanner = nil
         }
     }
+}
+
+extension BannerController: NotificationBannerDelegate {
+    public func notificationBannerWillAppear(_ banner: BaseNotificationBanner) {
+        if self.currentBanner == nil {
+            banner.isHidden = true
+        }
+    }
+
+    public func notificationBannerDidAppear(_ banner: BaseNotificationBanner) {
+        if self.currentBanner == nil {
+            banner.dismiss()
+        }
+    }
+
+    public func notificationBannerWillDisappear(_ banner: BaseNotificationBanner) { }
+
+    public func notificationBannerDidDisappear(_ banner: BaseNotificationBanner) { }
+
+
 }

--- a/Pollo/ViewControllers/CardController+Extension.swift
+++ b/Pollo/ViewControllers/CardController+Extension.swift
@@ -44,13 +44,13 @@ extension CardController: UIViewControllerTransitioningDelegate {
     }
 }
 
-extension CardController: NavigationTitleViewDelegate {
-
-    func navigationTitleViewNavigationButtonTapped() {
-        delegate?.navigationTitleViewNavigationButtonTapped()
-    }
-
-}
+//extension CardController: NavigationTitleViewDelegate {
+//
+//    func navigationTitleViewNavigationButtonTapped() {
+//        delegate?.navigationTitleViewNavigationButtonTapped()
+//    }
+//
+//}
 
 extension CardController: PollSectionControllerDelegate {
     

--- a/Pollo/ViewControllers/CardController.swift
+++ b/Pollo/ViewControllers/CardController.swift
@@ -17,7 +17,7 @@ protocol CardControllerDelegate: class {
     
     func cardControllerDidStartNewPoll(poll: Poll)
     func cardControllerWillDisappear(with pollsDateModel: PollsDateModel, numberOfPeople: Int)
-    func navigationTitleViewNavigationButtonTapped()
+//    func navigationTitleViewNavigationButtonTapped()
     func pollDeleted(_ pollID: String, userRole: UserRole)
     func pollDeletedLive()
     func pollEnded(_ poll: Poll, userRole: UserRole)
@@ -85,7 +85,7 @@ class CardController: UIViewController {
         tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTap))
         view.addGestureRecognizer(tapGestureRecognizer)
         
-        setupNavBar()
+//        setupNavBar()
         setupViews()
         socket.updateDelegate(self)
         do {
@@ -183,28 +183,28 @@ class CardController: UIViewController {
         }
     }
     
-    func setupNavBar() {
-        navigationController?.setNavigationBarHidden(false, animated: false)
-        // REMOVE BOTTOM SHADOW
-        navigationController?.navigationBar.setBackgroundImage(UIImage(), for: UIBarMetrics.default)
-        navigationController?.navigationBar.shadowImage = UIImage()
-        let textHeight = navigationController?.navigationBar.frame.height ?? 0
-        navigationTitleView = getNavigationTitleView(primaryText: session.name, primaryTextHeight: textHeight, secondaryText: "Code: \(session.code)", secondaryTextHeight: textHeight, userRole: userRole, delegate: self)
-        self.navigationItem.titleView = navigationTitleView
-        
-        let backImage = UIImage(named: "back")?.withRenderingMode(.alwaysOriginal)
-        self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: backImage, style: .done, target: self, action: #selector(goBack))
-        
-        if userRole == .admin {
-            createPollButton = UIButton()
-            createPollButton.isHidden = session.isLive ?? false
-            createPollButton.setImage(#imageLiteral(resourceName: "whiteCreatePoll"), for: .normal)
-            createPollButton.addTarget(self, action: #selector(createPollBtnPressed), for: .touchUpInside)
-            let createPollBarButton = UIBarButtonItem(customView: createPollButton)
-            self.navigationItem.rightBarButtonItems = [createPollBarButton]
-        }
-
-    }
+//    func setupNavBar() {
+//        navigationController?.setNavigationBarHidden(false, animated: false)
+//        // REMOVE BOTTOM SHADOW
+//        navigationController?.navigationBar.setBackgroundImage(UIImage(), for: UIBarMetrics.default)
+//        navigationController?.navigationBar.shadowImage = UIImage()
+//        let textHeight = navigationController?.navigationBar.frame.height ?? 0
+//        navigationTitleView = getNavigationTitleView(primaryText: session.name, primaryTextHeight: textHeight, secondaryText: "Code: \(session.code)", secondaryTextHeight: textHeight, userRole: userRole, delegate: self)
+//        self.navigationItem.titleView = navigationTitleView
+//
+//        let backImage = UIImage(named: "back")?.withRenderingMode(.alwaysOriginal)
+//        self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: backImage, style: .done, target: self, action: #selector(goBack))
+//
+//        if userRole == .admin {
+//            createPollButton = UIButton()
+//            createPollButton.isHidden = session.isLive ?? false
+//            createPollButton.setImage(#imageLiteral(resourceName: "whiteCreatePoll"), for: .normal)
+//            createPollButton.addTarget(self, action: #selector(createPollBtnPressed), for: .touchUpInside)
+//            let createPollBarButton = UIBarButtonItem(customView: createPollButton)
+//            self.navigationItem.rightBarButtonItems = [createPollBarButton]
+//        }
+//
+//    }
     
     // MARK: Helpers
     func updateCountLabelText() {

--- a/Pollo/ViewControllers/PollsDateViewController.swift
+++ b/Pollo/ViewControllers/PollsDateViewController.swift
@@ -12,10 +12,6 @@ import Presentr
 import UIKit
 import NotificationBannerSwift
 
-protocol PollsDateViewControllerDelegate: class {
-    func pollsDateViewControllerWasPopped(for userRole: UserRole)
-}
-
 class PollsDateViewController: UIViewController {
     
     // MARK: - View vars
@@ -33,16 +29,16 @@ class PollsDateViewController: UIViewController {
     var session: Session!
     var socket: Socket!
     var userRole: UserRole!
-    weak var delegate: PollsDateViewControllerDelegate?
+//    weak var delegate: PollsDateViewControllerDelegate?
     
     // MARK: - Constants
     let collectionViewTopPadding: CGFloat = 20
     let countLabelWidth: CGFloat = 42.0
     let insetPadding: CGFloat = 16
     
-    init(delegate: PollsDateViewControllerDelegate, pollsDateArray: [PollsDateModel], session: Session, userRole: UserRole) {
+    init(pollsDateArray: [PollsDateModel], session: Session, userRole: UserRole) {
         super.init(nibName: nil, bundle: nil)
-        self.delegate = delegate
+//        self.delegate = delegate
         self.pollsDateArray = pollsDateArray
         self.session = session
         self.userRole = userRole
@@ -53,7 +49,8 @@ class PollsDateViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .darkestGrey
         setupViews()
-        setupNavBar()
+//        navigationController?.setNavigationBarHidden(true, animated: false)
+//        setupNavBar()
         self.socket = Socket(id: "\(session.id)", delegate: self)
     }
     
@@ -99,30 +96,31 @@ class PollsDateViewController: UIViewController {
             make.width.equalToSuperview()
             make.centerX.equalToSuperview()
         }
-        BannerController.shared.show(NotificationBanner.connectingBanner())
+        (self.parent as? PollingViewController)?.currentBanner = NotificationBanner.connectingBanner()
+//        BannerController.shared.show(NotificationBanner.connectingBanner())
     }
     
-    func setupNavBar() {
-        navigationController?.setNavigationBarHidden(false, animated: false)
-        // REMOVE BOTTOM SHADOW
-        navigationController?.navigationBar.setBackgroundImage(UIImage(), for: UIBarMetrics.default)
-        navigationController?.navigationBar.shadowImage = UIImage()
-        let textHeight = navigationController?.navigationBar.frame.height ?? 0
-        navigationTitleView = getNavigationTitleView(primaryText: session.name, primaryTextHeight: textHeight, secondaryText: "Code: \(session.code)", secondaryTextHeight: textHeight, userRole: userRole, delegate: self)
-        self.navigationItem.titleView = navigationTitleView
-        
-        let backImage = UIImage(named: "back")?.withRenderingMode(.alwaysOriginal)
-        self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: backImage, style: .done, target: self, action: #selector(goBack))
-        
-        if userRole == .admin {
-            createPollButton = UIButton()
-            createPollButton.isHidden = pollsDateArray.last?.polls.last?.state == .live
-            createPollButton.setImage(#imageLiteral(resourceName: "whiteCreatePoll"), for: .normal)
-            createPollButton.addTarget(self, action: #selector(createPollBtnPressed), for: .touchUpInside)
-            let createPollBarButton = UIBarButtonItem(customView: createPollButton)
-            self.navigationItem.rightBarButtonItems = [createPollBarButton]
-        }
-    }
+//    func setupNavBar() {
+//        navigationController?.setNavigationBarHidden(false, animated: false)
+//        // REMOVE BOTTOM SHADOW
+//        navigationController?.navigationBar.setBackgroundImage(UIImage(), for: UIBarMetrics.default)
+//        navigationController?.navigationBar.shadowImage = UIImage()
+//        let textHeight = navigationController?.navigationBar.frame.height ?? 0
+//        navigationTitleView = getNavigationTitleView(primaryText: session.name, primaryTextHeight: textHeight, secondaryText: "Code: \(session.code)", secondaryTextHeight: textHeight, userRole: userRole, delegate: self)
+//        self.navigationItem.titleView = navigationTitleView
+//
+//        let backImage = UIImage(named: "back")?.withRenderingMode(.alwaysOriginal)
+//        self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: backImage, style: .done, target: self, action: #selector(goBack))
+//
+//        if userRole == .admin {
+//            createPollButton = UIButton()
+//            createPollButton.isHidden = pollsDateArray.last?.polls.last?.state == .live
+//            createPollButton.setImage(#imageLiteral(resourceName: "whiteCreatePoll"), for: .normal)
+//            createPollButton.addTarget(self, action: #selector(createPollBtnPressed), for: .touchUpInside)
+//            let createPollBarButton = UIBarButtonItem(customView: createPollButton)
+//            self.navigationItem.rightBarButtonItems = [createPollBarButton]
+//        }
+//    }
 
     // MARK: ACTIONS
     @objc func createPollBtnPressed() {
@@ -136,35 +134,35 @@ class PollsDateViewController: UIViewController {
         return networking(Endpoint.deleteSession(with: id)).decode()
     }
     
-    @objc func goBack() {
-        socket.updateDelegate(nil)
-        socket.socket.disconnect()
-        BannerController.shared.dismiss()
-        self.navigationController?.setNavigationBarHidden(true, animated: false)
-        self.navigationController?.popViewController(animated: true)
-        if pollsDateArray.isEmpty && session.name == session.code {
-            deleteSession(with: session.id).observe { [weak self] result in
-                guard let `self` = self else { return }
-                DispatchQueue.main.async {
-                    switch result {
-                    case .value(let response):
-                        if response.success {
-                            self.delegate?.pollsDateViewControllerWasPopped(for: self.userRole)
-                        } else {
-                            let alertController = self.createAlert(title: "Error", message: "Failed to delete session. Try again!")
-                            self.present(alertController, animated: true, completion: nil)
-                        }
-                    case .error(let error):
-                        print(error)
-                        let alertController = self.createAlert(title: "Error", message: "Failed to delete session. Try again!")
-                        self.present(alertController, animated: true, completion: nil)
-                    }
-                }
-            }
-        } else {
-            self.delegate?.pollsDateViewControllerWasPopped(for: self.userRole)
-        }
-    }
+//    @objc func goBack() {
+//        socket.updateDelegate(nil)
+//        socket.socket.disconnect()
+//        BannerController.shared.dismiss()
+//        self.navigationController?.setNavigationBarHidden(true, animated: false)
+//        self.navigationController?.popViewController(animated: true)
+//        if pollsDateArray.isEmpty && session.name == session.code {
+//            deleteSession(with: session.id).observe { [weak self] result in
+//                guard let `self` = self else { return }
+//                DispatchQueue.main.async {
+//                    switch result {
+//                    case .value(let response):
+//                        if response.success {
+//                            self.delegate?.pollsDateViewControllerWasPopped(for: self.userRole)
+//                        } else {
+//                            let alertController = self.createAlert(title: "Error", message: "Failed to delete session. Try again!")
+//                            self.present(alertController, animated: true, completion: nil)
+//                        }
+//                    case .error(let error):
+//                        print(error)
+//                        let alertController = self.createAlert(title: "Error", message: "Failed to delete session. Try again!")
+//                        self.present(alertController, animated: true, completion: nil)
+//                    }
+//                }
+//            }
+//        } else {
+//            self.delegate?.pollsDateViewControllerWasPopped(for: self.userRole)
+//        }
+//    }
     
     func getMembers(with id: String) -> Future<Response<[GetMemberResponse]>> {
         return networking(Endpoint.getMembers(with: id)).decode()
@@ -172,9 +170,5 @@ class PollsDateViewController: UIViewController {
     
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    override var preferredStatusBarStyle: UIStatusBarStyle {
-        return .lightContent
     }
 }

--- a/Pollo/ViewControllers/PollsViewController+Extension.swift
+++ b/Pollo/ViewControllers/PollsViewController+Extension.swift
@@ -89,8 +89,8 @@ extension PollsViewController: PollsCellDelegate {
                             }
                         }
                     }
-                    let pollsDateViewController = PollsDateViewController(delegate: self, pollsDateArray: pollsDateArray.reversed(), session: session, userRole: userRole)
-                    self.navigationController?.pushViewController(pollsDateViewController, animated: true)
+                    let pollingViewController = PollingViewController(delegate: self, pollsDateArray: pollsDateArray.reversed(), session: session, userRole: userRole)
+                    self.navigationController?.pushViewController(pollingViewController, animated: true)
                     self.navigationController?.setNavigationBarHidden(false, animated: true)
                     withCell.hideOpenSessionActivityIndicatorView()
                     self.isOpeningGroup = false
@@ -205,7 +205,7 @@ extension PollsViewController: UIGestureRecognizerDelegate {
     
 }
 
-extension PollsViewController: PollsDateViewControllerDelegate {
+extension PollsViewController: PollingViewControllerDelegate {
 
     func pollsDateViewControllerWasPopped(for userRole: UserRole) {
         reloadSessions(for: userRole) { sessions in

--- a/Pollo/ViewControllers/PollsViewController.swift
+++ b/Pollo/ViewControllers/PollsViewController.swift
@@ -368,8 +368,10 @@ class PollsViewController: UIViewController {
                     let session = sessionResponse.data
                     session.isLive = false
                     self.hideNewGroupActivityIndicatorView()
-                    let pollsDateViewController = PollsDateViewController(delegate: self, pollsDateArray: [], session: session, userRole: .admin)
-                    self.navigationController?.pushViewController(pollsDateViewController, animated: true)
+//                    let pollsDateViewController = PollsDateViewController(delegate: self, pollsDateArray: [], session: session, userRole: .admin)
+
+                    let pollingViewController = PollingViewController(delegate: self, pollsDateArray: [], session: session, userRole: .admin)
+                    self.navigationController?.pushViewController(pollingViewController, animated: true)
                     self.navigationController?.setNavigationBarHidden(false, animated: true)
                     Analytics.shared.log(with: CreatedGroupPayload())
                     self.createSessionTextField.text = ""
@@ -422,8 +424,8 @@ class PollsViewController: UIViewController {
                     }
                     
                     self.updateJoinSessionButton(canJoin: false)
-                    let pollsDateViewController = PollsDateViewController(delegate: self, pollsDateArray: pollsDateArray.reversed(), session: session, userRole: .member)
-                    self.navigationController?.pushViewController(pollsDateViewController, animated: true)
+                    let pollingViewController = PollingViewController(delegate: self, pollsDateArray: pollsDateArray.reversed(), session: session, userRole: .member)
+                    self.navigationController?.pushViewController(pollingViewController, animated: true)
                     self.navigationController?.setNavigationBarHidden(false, animated: true)
                     Analytics.shared.log(with: JoinedGroupPayload())
                 }


### PR DESCRIPTION


## Overview

Fixed issue in which banners would appear and get stuck on `PollsViewController` when presented after a delay/connection after `PollsDateViewController` was popped. 



## Changes Made

Conformed banners to a delegate, added a check if the `currentBanner` is nil, if so then hide the new banner.



## Test Coverage

Manual testing, pop between VCs when banners are appearing.


## Related PRs or Issues (delete if not applicable)

#355 

