### PR TITLE
Fix indexing issue

### DIFF
--- a/Pollo/ViewControllers/CardController+Extension.swift
+++ b/Pollo/ViewControllers/CardController+Extension.swift
@@ -307,9 +307,7 @@ extension CardController: SocketDelegate {
         }
         guard let deleteIndex = pollsDateModel.polls.firstIndex(where: { $0.id == pollID }) else { return }
         pollsDateModel.polls.remove(at: deleteIndex)
-        if currentIndex != 0 {
-            currentIndex = currentIndex >= deleteIndex ? currentIndex - 1 : currentIndex
-        }
+        currentIndex = currentIndex == pollsDateModel.polls.count ? currentIndex - 1 : currentIndex
         updateCountLabelText()
         adapter.performUpdates(animated: true, completion: nil)
     }
@@ -321,9 +319,7 @@ extension CardController: SocketDelegate {
         }
         guard let deleteIndex = pollsDateModel.polls.firstIndex(where: { $0.state == .live }) else { return }
         pollsDateModel.polls.remove(at: deleteIndex)
-        if currentIndex != 0 {
-            currentIndex = currentIndex >= deleteIndex ? currentIndex - 1 : currentIndex
-        }
+        currentIndex = currentIndex == pollsDateModel.polls.count ? currentIndex - 1 : currentIndex
         updateCountLabelText()
         adapter.performUpdates(animated: false, completion: nil)
         if pollsDateModel.polls.isEmpty {
@@ -437,7 +433,7 @@ extension CardController: EditPollViewControllerDelegate {
         adapter.performUpdates(animated: true) { completed in
             if completed && !self.pollsDateModel.polls.isEmpty {
                 // Move current index based on which poll was deleted
-                self.currentIndex = self.currentIndex == 0 ? self.currentIndex : self.currentIndex - 1
+                self.currentIndex = self.currentIndex == self.pollsDateModel.polls.count ? self.currentIndex - 1 : self.currentIndex
             }
             self.updateCountLabelText()
             if self.pollsDateModel.polls.isEmpty {


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

There was an indexing issue where deleting a poll would make the indexes act as though you go to the previous poll rather than all the polls to your right shifting left (as is the current behavior). Issue is now fixed.

## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

There was some incorrect logic in the previous code that may have been based on a previous version of the polls moving into place. Since the previous code would make me go back one more index than I should have, I simply made it so that my currentIndex was retained upon deleting a poll. The only issue with this is deleting the last poll, in which this logic would result in 3/3 turning into 3/2, so for this case I subtract the currentIndex by one.


## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

Manual testing on both student and professor side. Since some previous code involved `currentIndex >= deleteIndex`, I also tested (specifically on student side) being on a poll before, after, the deleted poll (and also being on the deleted poll itself).


## Next Steps

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->

I'll be checking in with designers to fix up the current design issues to ensure they don't pile up and simultaneously bug bashing infamous #328


## Related PRs or Issues

<!-- List related PRs against other branches/repositories. -->

#357


## Screenshots

<!-- This could include of screenshots of the new feature / proof that the changes work. -->
In these GIFs, pay attention to the current poll index. I do two tests in each GIF, deleting when live polling and when offline.


### Student
To note when I'm testing live and offline, take a look at when Open for Responses changes to Poll Closed

<details>
  <summary>Student Screen - Before</summary>

![ezgif com-resize (4)](https://user-images.githubusercontent.com/21962778/74600609-e4450600-5061-11ea-9ef6-7b6e928fd76a.gif)
</details>

<details>
  <summary>Student Screen - After</summary>

![ezgif com-resize (5)](https://user-images.githubusercontent.com/21962778/74600633-430a7f80-5062-11ea-9a4d-5426a6a4cb39.gif)
</details>

### Professor
To note when I'm testing live and offline, take a look at when End Poll changes to Share Results (and when the + button appears on the upper right)

<details>
  <summary>Professor Screen - Before</summary>

![ezgif com-resize (6)](https://user-images.githubusercontent.com/21962778/74600650-85cc5780-5062-11ea-8f53-25d433eb156e.gif)
</details>

<details>
  <summary>Professor Screen - After</summary>

![ezgif com-resize (7)](https://user-images.githubusercontent.com/21962778/74600675-c2984e80-5062-11ea-86d9-8c476fdd63e1.gif)
</details>
