### PR TITLE
Fixed banner persistence issue

### DIFF
--- a/Pollo.xcodeproj/project.pbxproj
+++ b/Pollo.xcodeproj/project.pbxproj
@@ -1147,7 +1147,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				INFOPLIST_FILE = Pollo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1281,7 +1281,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				INFOPLIST_FILE = Pollo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1434,7 +1434,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				INFOPLIST_FILE = Pollo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1460,7 +1460,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				INFOPLIST_FILE = Pollo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;

--- a/Pollo/Supporting/BannerController.swift
+++ b/Pollo/Supporting/BannerController.swift
@@ -35,6 +35,7 @@ public class BannerController {
 }
 
 extension BannerController: NotificationBannerDelegate {
+
     public func notificationBannerWillAppear(_ banner: BaseNotificationBanner) {
         banner.isHidden = self.currentBanner == nil
     }
@@ -48,6 +49,5 @@ extension BannerController: NotificationBannerDelegate {
     public func notificationBannerWillDisappear(_ banner: BaseNotificationBanner) { }
 
     public func notificationBannerDidDisappear(_ banner: BaseNotificationBanner) { }
-
 
 }

--- a/Pollo/Supporting/BannerController.swift
+++ b/Pollo/Supporting/BannerController.swift
@@ -36,9 +36,7 @@ public class BannerController {
 
 extension BannerController: NotificationBannerDelegate {
     public func notificationBannerWillAppear(_ banner: BaseNotificationBanner) {
-        if self.currentBanner == nil {
-            banner.isHidden = true
-        }
+        banner.isHidden = self.currentBanner == nil
     }
 
     public func notificationBannerDidAppear(_ banner: BaseNotificationBanner) {

--- a/Pollo/Supporting/BannerController.swift
+++ b/Pollo/Supporting/BannerController.swift
@@ -16,6 +16,7 @@ public class BannerController {
     var currentBanner: BaseNotificationBanner?
 
     func show(_ banner: BaseNotificationBanner) {
+        banner.delegate = self
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             self.currentBanner?.dismiss()
@@ -31,4 +32,24 @@ public class BannerController {
             self.currentBanner = nil
         }
     }
+}
+
+extension BannerController: NotificationBannerDelegate {
+    public func notificationBannerWillAppear(_ banner: BaseNotificationBanner) {
+        if self.currentBanner == nil {
+            banner.isHidden = true
+        }
+    }
+
+    public func notificationBannerDidAppear(_ banner: BaseNotificationBanner) {
+        if self.currentBanner == nil {
+            banner.dismiss()
+        }
+    }
+
+    public func notificationBannerWillDisappear(_ banner: BaseNotificationBanner) { }
+
+    public func notificationBannerDidDisappear(_ banner: BaseNotificationBanner) { }
+
+
 }


### PR DESCRIPTION
(This is the right branch!)

## Overview

Fixed issue in which banners would appear and get stuck on `PollsViewController` when presented after a delay/connection after `PollsDateViewController` was popped. 



## Changes Made

Conformed banners to a delegate, added a check if the `currentBanner` is nil, if so then hide the new banner.



## Test Coverage

Manual testing, pop between VCs when banners are appearing.


## Related PRs or Issues (delete if not applicable)

#355 

