### PR TITLE
Banner & Misc. Bug Fixes

### DIFF
--- a/Pollo/SectionControllers/CardSectionControllers/PollOptionsSectionController.swift
+++ b/Pollo/SectionControllers/CardSectionControllers/PollOptionsSectionController.swift
@@ -11,6 +11,7 @@ import IGListKit
 protocol PollOptionsSectionControllerDelegate {
     
     var userRole: UserRole { get }
+    var isConnected: Bool { get }
     
     func pollOptionsSectionControllerDidSubmitChoice(sectionController: PollOptionsSectionController, choice: String, index: Int?)
     
@@ -60,6 +61,10 @@ extension PollOptionsSectionController: PollOptionsCellDelegate {
     
     var userRole: UserRole {
         return delegate.userRole
+    }
+
+    var isConnected: Bool {
+        return delegate.isConnected
     }
 
     func pollOptionsCellDidSubmitChoice(choice: String, index: Int) {

--- a/Pollo/SectionControllers/PollSectionController.swift
+++ b/Pollo/SectionControllers/PollSectionController.swift
@@ -12,6 +12,7 @@ import IGListKit
 protocol PollSectionControllerDelegate: class {
     
     var role: UserRole { get }
+    var isConnected: Bool { get }
 
     func pollSectionControllerDidEditPoll(sectionController: PollSectionController, poll: Poll)
     func pollSectionControllerDidEndPoll(sectionController: PollSectionController, poll: Poll)
@@ -60,6 +61,10 @@ extension PollSectionController: CardCellDelegate {
     
     var userRole: UserRole {
         return delegate.role
+    }
+
+    var isConnected: Bool {
+        return delegate.isConnected
     }
     
     func cardCellDidSubmitChoice(cardCell: CardCell, choice: String, index: Int?) {

--- a/Pollo/ViewControllers/CardController+Extension.swift
+++ b/Pollo/ViewControllers/CardController+Extension.swift
@@ -224,7 +224,7 @@ extension CardController: SocketDelegate {
     func sessionConnected() {
         let banner = NotificationBanner.connectedBanner()
         BannerController.shared.show(banner)
-        collectionView.isUserInteractionEnabled = true
+        isConnected = true
     }
     
     func sessionDisconnected() {
@@ -237,14 +237,14 @@ extension CardController: SocketDelegate {
             }
 
             BannerController.shared.show(banner)
-            self.collectionView.isUserInteractionEnabled = false
+            self.isConnected = false
         }
     }
 
     func sessionReconnecting(reason: String) {
         let banner = NotificationBanner.reconnectingBanner(reason: reason)
         BannerController.shared.show(banner)
-        collectionView.isUserInteractionEnabled = false
+        isConnected = false
 
         socket.socket.connect(timeoutAfter: 10) { [weak self] in
             guard let `self` = self else { return }

--- a/Pollo/ViewControllers/CardController.swift
+++ b/Pollo/ViewControllers/CardController.swift
@@ -14,7 +14,7 @@ import NotificationBannerSwift
 import Reachability
 
 protocol CardControllerDelegate: class {
-    
+
     func cardControllerDidStartNewPoll(poll: Poll)
     func cardControllerWillDisappear(with pollsDateModel: PollsDateModel, numberOfPeople: Int)
     func navigationTitleViewNavigationButtonTapped()
@@ -54,6 +54,7 @@ class CardController: UIViewController {
     var wasScrolledToIndex: Int!
     weak var delegate: CardControllerDelegate?
     var reachability: Reachability!
+    var isConnected: Bool = true
     
     // MARK: - Constants
     let collectionViewHorizontalInset: CGFloat = 17.0

--- a/Pollo/ViewControllers/PollsDateViewController.swift
+++ b/Pollo/ViewControllers/PollsDateViewController.swift
@@ -140,7 +140,6 @@ class PollsDateViewController: UIViewController {
         socket.updateDelegate(nil)
         socket.socket.disconnect()
         BannerController.shared.dismiss()
-        self.navigationController?.setNavigationBarHidden(true, animated: false)
         self.navigationController?.popViewController(animated: true)
         if pollsDateArray.isEmpty && session.name == session.code {
             deleteSession(with: session.id).observe { [weak self] result in

--- a/Pollo/Views/Cards/CardCell.swift
+++ b/Pollo/Views/Cards/CardCell.swift
@@ -14,6 +14,7 @@ import UIKit
 protocol CardCellDelegate: class {
 
     var userRole: UserRole { get }
+    var isConnected: Bool { get }
 
     func cardCellDidEditPoll(cardCell: CardCell, poll: Poll)
     func cardCellDidEndPoll(cardCell: CardCell, poll: Poll)
@@ -277,6 +278,10 @@ extension CardCell: PollOptionsSectionControllerDelegate {
     
     var userRole: UserRole {
         return delegate.userRole
+    }
+
+    var isConnected: Bool {
+        return delegate.isConnected
     }
     
     func pollOptionsSectionControllerDidSubmitChoice(sectionController: PollOptionsSectionController, choice: String, index: Int?) {

--- a/Pollo/Views/Cards/PollOptionsCell.swift
+++ b/Pollo/Views/Cards/PollOptionsCell.swift
@@ -12,6 +12,7 @@ import IGListKit
 protocol PollOptionsCellDelegate: class {
     
     var userRole: UserRole { get }
+    var isConnected: Bool { get }
     
     func pollOptionsCellDidSubmitChoice(choice: String, index: Int)
     
@@ -195,6 +196,10 @@ extension PollOptionsCell: MCResultSectionControllerDelegate {
     var userRole: UserRole {
         return delegate.userRole
     }
+
+    var isConnected: Bool {
+        return delegate.isConnected
+    }
     
 }
 
@@ -205,6 +210,7 @@ extension PollOptionsCell: MCChoiceSectionControllerDelegate {
     }
     
     func mcChoiceSectionControllerWasSelected(sectionController: MCChoiceSectionController) {
+        guard isConnected else { return }
         switch pollOptionsModel.type {
         case .mcChoice(choiceModels: var mcChoiceModels):
             if mcSelectedIndex != NSNotFound {


### PR DESCRIPTION
## Overview

Fixes some bugs related to banners


## Changes Made

- Only disable changing an answer when socket is disconnected, previously the entire CollectionView was disabled but that would prevent users from viewing previous polls.
- Fixed jumpiness in transition when popping `PollsDateViewController` due to the navigation bar being hidden.


## Test Coverage

Manual testing



## Next Steps

- I think I still have some issues with banners persisting but it only appears to happen when using breakpoints and the simulator, going to connect my phone to the debugger and try to replicate.


## Related PRs or Issues

#365 



## Screenshots

<!-- This could include of screenshots of the new feature / proof that the changes work. -->

<details>

  <summary>Nav bar transition: Before</summary>


![navbar-before](https://user-images.githubusercontent.com/34046832/75381846-7ee5e600-58a7-11ea-8ef9-1bbb4684a1c6.gif)

 </details>

<details>

<summary>Nav bar transition: After</summary>

![navbar-after](https://user-images.githubusercontent.com/34046832/75381873-89a07b00-58a7-11ea-8c2d-872fc8269587.gif)


</details>
