### PR TITLE
Disabled group controls page

### DIFF
--- a/Pollo/ViewControllers/PollsDateViewController+Extension.swift
+++ b/Pollo/ViewControllers/PollsDateViewController+Extension.swift
@@ -120,7 +120,9 @@ extension PollsDateViewController: PollBuilderViewControllerDelegate {
 extension PollsDateViewController: NavigationTitleViewDelegate {
 
     func navigationTitleViewNavigationButtonTapped() {
-        guard userRole == .admin else { return }
+        guard userRole != .admin && userRole != .member else { return }
+
+        // This code will be executed when we reenable the settings page
         let pollsDateAttendanceArray = pollsDateArray.map { PollsDateAttendanceModel(model: $0, isSelected: false) }
         getMembers(with: session?.id ?? "").observe { [weak self] result in
             guard let `self` = self else { return }

--- a/Pollo/ViewControllers/PollsDateViewController+Extension.swift
+++ b/Pollo/ViewControllers/PollsDateViewController+Extension.swift
@@ -120,24 +120,8 @@ extension PollsDateViewController: PollBuilderViewControllerDelegate {
 extension PollsDateViewController: NavigationTitleViewDelegate {
 
     func navigationTitleViewNavigationButtonTapped() {
-        guard userRole != .admin && userRole != .member else { return }
-
-        // This code will be executed when we reenable the settings page
-        let pollsDateAttendanceArray = pollsDateArray.map { PollsDateAttendanceModel(model: $0, isSelected: false) }
-        getMembers(with: session?.id ?? "").observe { [weak self] result in
-            guard let `self` = self else { return }
-            DispatchQueue.main.async {
-                switch result {
-                case .value(let response):
-                    let groupControlsVC = GroupControlsViewController(session: self.session, pollsDateAttendanceArray: pollsDateAttendanceArray, numMembers: response.data.count, delegate: self)
-                    self.navigationController?.pushViewController(groupControlsVC, animated: true)
-                case .error(let error):
-                    print(error)
-                    let alertController = self.createAlert(title: "Error", message: "Failed to load data. Try again!")
-                    self.present(alertController, animated: true, completion: nil)
-                }
-            }
-        }
+        // TODO: Push the group controls page once we re-enable
+        return
     }
 
 }

--- a/Pollo/ViewControllers/PollsDateViewController+Extension.swift
+++ b/Pollo/ViewControllers/PollsDateViewController+Extension.swift
@@ -121,7 +121,6 @@ extension PollsDateViewController: NavigationTitleViewDelegate {
 
     func navigationTitleViewNavigationButtonTapped() {
         // TODO: Push the group controls page once we re-enable
-        return
     }
 
 }

--- a/Pollo/Views/Cards/NavigationTitleView.swift
+++ b/Pollo/Views/Cards/NavigationTitleView.swift
@@ -77,7 +77,8 @@ class NavigationTitleView: UIView {
         primaryLabel.text = primaryText
         secondaryLabel.text = secondaryText
         self.delegate = delegate
-        arrowImageView.isHidden = delegate == nil || userRole == .member
+        // Hidden until settings page is reenabled
+        arrowImageView.isHidden = true
     }
     
     func setupConstraints() {


### PR DESCRIPTION
## Overview

For now, we are disabling the group controls/settings page as we are not offering exporting from mobile. 


## Changes Made

- Hid arrow on admin navigation bar
- Disabled nav bar tap action to do nothing



## Test Coverage

Manual testing



## Next Steps

- `GroupControlsViewController` is preserved but currently is just dead code. When we add back location restrictions and other settings, we will reuse this code. 
- We will reenable the arrow and tap action when we add these settings back in.

## Related PRs or Issues

#348 

## Screenshots

<!-- This could include of screenshots of the new feature / proof that the changes work. -->

<details>

  <summary>No more arrow in navigation bar on admin side</summary>


  ![Simulator Screen Shot - iPhone 11 Pro - 2020-02-26 at 15 26 49](https://user-images.githubusercontent.com/34046832/75386228-4b0ebe80-58af-11ea-9f06-442f0f2d9f72.png)
  

</details>
