### PR TITLE
Add button emphasis and fix responsive bugs

### DIFF
--- a/Pollo/SectionControllers/CardSectionControllers/QuestionSectionController.swift
+++ b/Pollo/SectionControllers/CardSectionControllers/QuestionSectionController.swift
@@ -33,6 +33,7 @@ class QuestionSectionController: ListSectionController {
         if userRole == .admin {
             questionLabelWidth -= LayoutConstants.moreButtonWidth
         }
+        // LayoutConstants.questionCellHeight unused here - see PR
         let cellHeight = questionModel.question.height(withConstrainedWidth: questionLabelWidth, font: ._20BoldFont)
         return CGSize(width: containerSize.width, height: cellHeight)
     }

--- a/Pollo/SectionControllers/CardSectionControllers/QuestionSectionController.swift
+++ b/Pollo/SectionControllers/CardSectionControllers/QuestionSectionController.swift
@@ -33,7 +33,6 @@ class QuestionSectionController: ListSectionController {
         if userRole == .admin {
             questionLabelWidth -= LayoutConstants.moreButtonWidth
         }
-        // LayoutConstants.questionCellHeight unused here - see PR
         let cellHeight = questionModel.question.height(withConstrainedWidth: questionLabelWidth, font: ._20BoldFont)
         return CGSize(width: containerSize.width, height: cellHeight)
     }

--- a/Pollo/Supporting/Constants.swift
+++ b/Pollo/Supporting/Constants.swift
@@ -70,7 +70,7 @@ struct LayoutConstants {
     static let pollMiscellaneousCellHeight: CGFloat = 30
     static let pollOptionsBottomPadding: CGFloat = 16
     static let pollOptionsPadding: CGFloat = 18
-    static let questionCellHeight: CGFloat = 60
+    static let questionCellHeight: CGFloat = 24
     static let separatorLineCardCellHeight: CGFloat = 1
     static let separatorLineSettingsCellHeight: CGFloat = 5
 }

--- a/Pollo/Supporting/Constants.swift
+++ b/Pollo/Supporting/Constants.swift
@@ -70,7 +70,6 @@ struct LayoutConstants {
     static let pollMiscellaneousCellHeight: CGFloat = 30
     static let pollOptionsBottomPadding: CGFloat = 16
     static let pollOptionsPadding: CGFloat = 18
-    static let questionCellHeight: CGFloat = 24
     static let separatorLineCardCellHeight: CGFloat = 1
     static let separatorLineSettingsCellHeight: CGFloat = 5
 }

--- a/Pollo/Views/Cards/CardCell.swift
+++ b/Pollo/Views/Cards/CardCell.swift
@@ -273,7 +273,9 @@ extension CardCell: PollOptionsSectionControllerDelegate {
     }
     
     var maxCellHeight: CGFloat {
-        let cardCellTopHeight = LayoutConstants.hamburgerCardCellHeight + LayoutConstants.questionCellHeight + LayoutConstants.pollMiscellaneousCellHeight + LayoutConstants.separatorLineCardCellHeight
+        let questionCellWidth = self.frame.width - LayoutConstants.cardHorizontalPadding * 2 - LayoutConstants.moreButtonWidth
+        let questionCellHeight = questionModel.question.height(forConstrainedWidth: questionCellWidth, font: ._20BoldFont)
+        let cardCellTopHeight = LayoutConstants.hamburgerCardCellHeight + questionCellHeight + LayoutConstants.pollMiscellaneousCellHeight + LayoutConstants.separatorLineCardCellHeight
         let belowAdminCardCellHeight = questionButtonHeight + questionButtonBottomPadding + timerLabelFontSize + timerLabelBottomPadding + responsiveAdminPadding
         return self.frame.height - (cardCellTopHeight + (delegate.userRole == .admin ? belowAdminCardCellHeight : responsiveStudentPadding))
     }

--- a/Pollo/Views/Cards/CardCell.swift
+++ b/Pollo/Views/Cards/CardCell.swift
@@ -53,12 +53,12 @@ class CardCell: UICollectionViewCell {
     let questionButtonCornerRadius: CGFloat = 23.0
     let questionButtonFontSize: CGFloat = 16.0
     let questionButtonHeight: CGFloat = 47.0
-    let questionButtonWidth: CGFloat = 170.0
+    let questionButtonWidth: CGFloat = 160.0
     let responsiveAdminPadding: CGFloat = 32.0
     let responsiveStudentPadding: CGFloat = 50.0
     let resultsSharedText = "Results Shared"
     let shareResultsText = "Share Results"
-    let timerLabelBottomPadding: CGFloat =  91.0
+    let timerLabelBottomPadding: CGFloat = 45.0
     let timerLabelFontSize: CGFloat = 14.0
     
     override init(frame: CGRect) {
@@ -113,6 +113,7 @@ class CardCell: UICollectionViewCell {
         timerLabel.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.bottom.equalToSuperview().inset(timerLabelBottomPadding)
+            make.height.equalTo(timerLabelFontSize)
         }
         
         questionButton.snp.makeConstraints { make in
@@ -133,8 +134,8 @@ class CardCell: UICollectionViewCell {
         timerLabel.isHidden = !(poll.state == .live) || isMember
         if poll.state == .live {
             questionButton.setTitle(endPollText, for: .normal)
-            questionButton.setTitleColor(.white, for: .normal)
-            questionButton.layer.borderColor = UIColor.white.cgColor
+            questionButton.setTitleColor(.clickerRed, for: .normal)
+            questionButton.layer.borderColor = UIColor.clickerRed.cgColor
             setTimerText()
             runTimer()
         } else if poll.state == .ended {
@@ -178,6 +179,8 @@ class CardCell: UICollectionViewCell {
         if poll.state == .live {
             poll.state = .ended
             questionButton.setTitle(shareResultsText, for: .normal)
+            questionButton.setTitleColor(.white, for: .normal)
+            questionButton.layer.borderColor = UIColor.white.cgColor
             timerLabel.isHidden = true
             miscellaneousModel = PollMiscellaneousModel(questionType: poll.type, pollState: .ended, totalResponses: miscellaneousModel.totalResponses, userRole: userRole, didSubmitChoice: poll.getSelected() != nil)
             adapter.performUpdates(animated: false, completion: nil)

--- a/Pollo/Views/Cards/CardCell.swift
+++ b/Pollo/Views/Cards/CardCell.swift
@@ -59,7 +59,7 @@ class CardCell: UICollectionViewCell {
     let resultsSharedText = "Results Shared"
     let shareResultsText = "Share Results"
     let timerLabelBottomPadding: CGFloat = 45.0
-    let timerLabelFontSize: CGFloat = 14.0
+    let timerLabelFontSize: CGFloat = 17.0
     
     override init(frame: CGRect) {
         super.init(frame: frame)


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

Added different colors to poll buttons to add emphasis to choices and fixed bugs not caught from before.



## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

- End Poll button is now red
- Button height is consistent after giving timer label a height anchor (for when the label has no text and defaults to zero height) 
https://stackoverflow.com/questions/45885086/why-uilabels-height-become-zero-if-doesnt-hold-any-text
- Removed questionCellHeight from constants (as it varies depending on text size)
- Fixed responsiveness to use appropriate questionCellHeight

## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

Manual testing

## Related PRs or Issues

<!-- List related PRs against other branches/repositories. -->

#383
#388 - may still have issues with OptionsGradientView if not related to button issue; if so, no consistent way to replicate found


## Screenshots

<!-- This could include of screenshots of the new feature / proof that the changes work. -->

<details>
<summary>Button Emphasis</summary>

![emphasis](https://user-images.githubusercontent.com/21962778/79698294-10ddef80-8256-11ea-87ff-0b94c8086455.gif)
</details>
<details>
<summary>Fixed responsiveness</summary>

![fixed padding](https://user-images.githubusercontent.com/21962778/79698328-4551ab80-8256-11ea-8e5c-75043aac4929.gif)
</details>
<details>
<summary>Responsiveness with long questions</summary>

![still works!](https://user-images.githubusercontent.com/21962778/79698338-4edb1380-8256-11ea-94a9-032ef9c83ef6.gif)
</details>
