### PR TITLE
Fix editButton width for long titles

### DIFF
--- a/Pollo/Views/Cards/QuestionCell.swift
+++ b/Pollo/Views/Cards/QuestionCell.swift
@@ -24,6 +24,7 @@ class QuestionCell: UICollectionViewCell {
     
     // MARK: - Constants
     let editButtonImageName = "dots"
+    let editButtonWidth = 18
     let questionLabelWidthScaleFactor: CGFloat = 0.75
     let untitledPollString = "Untitled Poll"
     
@@ -59,6 +60,7 @@ class QuestionCell: UICollectionViewCell {
             editButton.snp.makeConstraints { make in
                 make.trailing.equalToSuperview().inset(LayoutConstants.cardHorizontalPadding)
                 make.top.equalToSuperview()
+                make.width.equalTo(editButtonWidth)
             }
             
             questionLabel.snp.makeConstraints { make in


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

Fixed a constraint issue.



## Changes Made

The leading and trailing anchors were dependent on one another, so I went on Figma to find the constant value for the width to ensure it doesn't shrink.



## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

Manual testing on previous issues.

## Related PRs or Issues

#391 

Would've been a longer PR but #390 wasn't happening anymore..