### PR TITLE
More Misc. Bug Fixes

### DIFF
--- a/Pollo/Extensions/NotificationBanner+Shared.swift
+++ b/Pollo/Extensions/NotificationBanner+Shared.swift
@@ -13,7 +13,9 @@ import NotificationBannerSwift
 extension NotificationBanner {
 
     override public func isEqual(_ object: Any?) -> Bool {
-        guard let banner = object as? NotificationBanner, let title1 = self.titleLabel?.text, let title2 = banner.titleLabel?.text else { return false }
+        guard let banner = object as? NotificationBanner,
+            let title1 = self.titleLabel?.text,
+            let title2 = banner.titleLabel?.text else { return false }
         return title1 == title2
     }
 

--- a/Pollo/Extensions/NotificationBanner+Shared.swift
+++ b/Pollo/Extensions/NotificationBanner+Shared.swift
@@ -12,6 +12,11 @@ import NotificationBannerSwift
 
 extension NotificationBanner {
 
+    override public func isEqual(_ object: Any?) -> Bool {
+        guard let banner = object as? NotificationBanner, let title1 = self.titleLabel?.text, let title2 = banner.titleLabel?.text else { return false }
+        return title1 == title2
+    }
+
     static func connectingBanner() -> BaseNotificationBanner {
         let banner = StatusBarNotificationBanner(title: "Connecting...", style: .warning, colors: PolloBannerColors())
         banner.autoDismiss = false

--- a/Pollo/Models/Socket.swift
+++ b/Pollo/Models/Socket.swift
@@ -37,13 +37,15 @@ class Socket {
         socket = manager.socket(forNamespace: "/\(id)")
         
         socket.on(clientEvent: .connect) { _, _ in
+            guard let delegate = self.delegate else { return }
             let banner = NotificationBanner.connectedBanner()
             BannerController.shared.show(banner)
 
-            self.delegate?.sessionConnected()
+            delegate.sessionConnected()
         }
         
         socket.on(clientEvent: .disconnect) { _, _ in
+            guard let delegate = self.delegate else { return }
             let banner = NotificationBanner.disconnectedBanner()
             banner.onTap = { [weak self] in
                 guard let self = self else { return }
@@ -51,14 +53,15 @@ class Socket {
             }
             BannerController.shared.show(banner)
 
-            self.delegate?.sessionDisconnected()
+            delegate.sessionDisconnected()
         }
 
         socket.on(clientEvent: .reconnect) { ( _, _) in
+            guard let delegate = self.delegate else { return }
             let banner = NotificationBanner.reconnectingBanner()
             BannerController.shared.show(banner)
 
-            self.delegate?.sessionReconnecting()
+            delegate.sessionReconnecting()
         }
 
         socket.on(Routes.userStart) { socketData, _ in
@@ -116,6 +119,7 @@ class Socket {
 
     /// Manually reconnect socket to the server
     func manualReconnect() {
+        guard self.delegate != nil else { return }
         let banner = NotificationBanner.reconnectingBanner()
         BannerController.shared.show(banner)
 

--- a/Pollo/Supporting/BannerController.swift
+++ b/Pollo/Supporting/BannerController.swift
@@ -38,7 +38,7 @@ extension BannerController: NotificationBannerDelegate {
     }
 
     public func notificationBannerDidAppear(_ banner: BaseNotificationBanner) {
-        if self.currentBanner == nil {
+        if self.currentBanner == nil || banner != self.currentBanner {
             banner.dismiss()
         }
     }

--- a/Pollo/ViewControllers/CardController+Extension.swift
+++ b/Pollo/ViewControllers/CardController+Extension.swift
@@ -14,25 +14,19 @@ import UIKit
 extension CardController: ListAdapterDataSource {
     
     func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
-        if pollsDateModel.polls.isEmpty {
-            let type: EmptyStateType = .cardController(userRole: userRole)
-            return [EmptyStateModel(type: type)]
-        }
         return pollsDateModel.polls
     }
     
     func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
-        if object is Poll {
-            let pollSectionController = PollSectionController(delegate: self)
-            return pollSectionController
-        } else {
-            let emptyStateController = EmptyStateSectionController(session: session)
-            return emptyStateController
-        }
+        
+        let pollSectionController = PollSectionController(delegate: self)
+        return pollSectionController
     }
     
     func emptyView(for listAdapter: ListAdapter) -> UIView? {
-        return nil
+        let emptyCell = EmptyStateCell()
+        emptyCell.configure(for: EmptyStateModel(type: .cardController(userRole: userRole)), session: session)
+        return emptyCell
     }
 }
 
@@ -295,9 +289,6 @@ extension CardController: SocketDelegate {
         currentIndex = currentIndex == pollsDateModel.polls.count ? currentIndex - 1 : currentIndex
         updateCountLabelText()
         adapter.performUpdates(animated: false, completion: nil)
-        if pollsDateModel.polls.isEmpty {
-            goBack()
-        }
     }
     
     func receivedResults(_ poll: Poll, userRole: UserRole) {

--- a/Pollo/ViewControllers/PollsDateViewController+Extension.swift
+++ b/Pollo/ViewControllers/PollsDateViewController+Extension.swift
@@ -13,25 +13,18 @@ import UIKit
 extension PollsDateViewController: ListAdapterDataSource {
     
     func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
-        if pollsDateArray.isEmpty {
-            let type: EmptyStateType = .cardController(userRole: userRole)
-            return [EmptyStateModel(type: type)]
-        }
         return pollsDateArray
     }
     
     func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
-        if object is PollsDateModel {
-            let pollsDateSectionController = PollsDateSectionController(delegate: self)
-            return pollsDateSectionController
-        } else {
-            let emptyStateController = EmptyStateSectionController(session: session)
-            return emptyStateController
-        }
+        let pollsDateSectionController = PollsDateSectionController(delegate: self)
+        return pollsDateSectionController
     }
     
     func emptyView(for listAdapter: ListAdapter) -> UIView? {
-        return nil
+        let emptyCell = EmptyStateCell()
+        emptyCell.configure(for: EmptyStateModel(type: .cardController(userRole: userRole)), session: session)
+        return emptyCell
     }
 }
 


### PR DESCRIPTION

## Overview

- Fixed issue where banners were still being called when the presenting VC no longer exists
- Fixed strange banner race condition where banners were shown but not preserved as the `currentBanner`
- Fixed off-center empty states in CardController and prevented popping back to PollsDate when a live poll is deleted for consistency


## Test Coverage

Manual testing

## Related PRs or Issues (delete if not applicable)

#371
