### PR TITLE
Fixed Ghost/Non-deleting Polls

### DIFF
--- a/Pollo/Models/ListDiffableModels/Poll.swift
+++ b/Pollo/Models/ListDiffableModels/Poll.swift
@@ -76,7 +76,7 @@ class Poll: Codable {
     // MARK: - Constants
     let identifier = UUID().uuidString
     
-    init(createdAt: String? = nil, updatedAt: String? = nil, id: String = "", text: String, answerChoices: [PollResult], type: QuestionType, correctAnswer: String? = nil, userAnswers: [String: [PollChoice]], state: PollState) {
+    init(createdAt: String? = nil, updatedAt: String? = nil, id: String? = nil, text: String, answerChoices: [PollResult], type: QuestionType, correctAnswer: String? = nil, userAnswers: [String: [PollChoice]], state: PollState) {
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.id = id

--- a/Pollo/ViewControllers/PollsViewController+Extension.swift
+++ b/Pollo/ViewControllers/PollsViewController+Extension.swift
@@ -84,8 +84,7 @@ extension PollsViewController: PollsCellDelegate {
                             pollsDateArray[index].polls.append(contentsOf: response.polls)
                         } else {
                             response.polls.forEach { poll in
-                                let polls = [Poll(text: poll.text, answerChoices: poll.answerChoices, type: poll.type, correctAnswer: poll.correctAnswer, userAnswers: poll.userAnswers, state: poll.state)]
-                                pollsDateArray.append(PollsDateModel(date: response.date, polls: polls))
+                                pollsDateArray.append(PollsDateModel(date: response.date, polls: [poll]))
                             }
                         }
                     }

--- a/Pollo/ViewControllers/PollsViewController.swift
+++ b/Pollo/ViewControllers/PollsViewController.swift
@@ -420,8 +420,7 @@ class PollsViewController: UIViewController {
                             pollsDateArray[index].polls.append(contentsOf: response.polls)
                         } else {
                             response.polls.forEach { poll in
-                                let polls = [Poll(text: poll.text, answerChoices: poll.answerChoices, type: poll.type, correctAnswer: poll.correctAnswer, userAnswers: poll.userAnswers, state: poll.state)]
-                                pollsDateArray.append(PollsDateModel(date: response.date, polls: polls))
+                                pollsDateArray.append(PollsDateModel(date: response.date, polls: [poll]))
                             }
                         }
                         self.codeTextField.text = ""


### PR DESCRIPTION
## Overview

The issue was where polls were being deleted by an admin but weren't deleting from the student-side or the backend. This was due to Polls being created on the client side with empty string id's.



## Changes Made

- Construct Poll objects directly from the backend response instead of manually, which includes all information returned from the request, including `id`
- Prevented `id` from defaulting to "" in the `Poll` constructor



## Test Coverage

Manual testing

## Next steps

- Still gonna do a bit more testing with @chalo2000 to ensure that the issue is solved.


## Related PRs or Issues (delete if not applicable)

#328 