### PR TITLE
Fix no internet edge case

### DIFF
--- a/Pollo/AppDelegate.swift
+++ b/Pollo/AppDelegate.swift
@@ -192,7 +192,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, GIDSignInDelegate {
                 }
             }
             
-        } else {
+        } else if(didSignInSilently){
             self.pollsNavigationController.pushViewController(NoInternetViewController(), animated: false)
         }
     }

--- a/Pollo/AppDelegate.swift
+++ b/Pollo/AppDelegate.swift
@@ -192,7 +192,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, GIDSignInDelegate {
                 }
             }
             
-        } else if(didSignInSilently){
+        } else if didSignInSilently {
             self.pollsNavigationController.pushViewController(NoInternetViewController(), animated: false)
         }
     }


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

Previously, any call to the Google login signin function would force the No Internet screen to appear if an error occurred. This is typically fine, except when new users accidentally cancel showing or dismiss the Google login modal, forcing them to be stuck in the No Internet screen unless they reset the app.



## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

Only show the No Internet screen if didSignInSilently, which is only set to true when the user has already authenticated in the past (aka, not new users). Otherwise, do nothing to keep new users on Pollo's sign in screen.


## Test Coverage

Manual testing

## Related PRs or Issues

<!-- List related PRs against other branches/repositories. -->

#401 
