### PR TITLE
Fix Gradient View Bug

### DIFF
--- a/Pollo/Views/Cards/MCResultCell.swift
+++ b/Pollo/Views/Cards/MCResultCell.swift
@@ -101,14 +101,17 @@ class MCResultCell: UICollectionViewCell {
     override func updateConstraints() {
         guard let optionLabelText = optionLabel.text else { return }
         let optionLabelWidth = optionLabelText.width(withConstrainedHeight: bounds.height, font: optionLabel.font)
-        let maxWidth = bounds.width - horizontalPadding - numPercentSelectedTrailingPadding - 2 * horizontalPadding
-        
+        var maxLabelWidth = bounds.width - horizontalPadding - numPercentSelectedTrailingPadding - 2 * horizontalPadding
+        if userRole == .member {
+            maxLabelWidth -= dotViewLength + horizontalPadding
+        }
+
         // If we already laid out constraints before, we should only update the
         // highlightView width constraint
         if didLayoutConstraints {
-            let useMaxWidth = optionLabelWidth >= maxWidth || !showCorrectAnswer
+            let useMaxWidth = optionLabelWidth >= maxLabelWidth || !showCorrectAnswer
             optionLabel.snp.updateConstraints { make in
-                make.width.equalTo(useMaxWidth ? maxWidth : optionLabelWidth)
+                make.width.equalTo(useMaxWidth ? maxLabelWidth : optionLabelWidth)
             }
             UIView.animate(withDuration: 0.5) { [weak self] in
                 guard let self = self else { return }
@@ -141,22 +144,20 @@ class MCResultCell: UICollectionViewCell {
         }
         
         containerView.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(horizontalPadding + (userRole == .admin ? 0 : horizontalPadding + dotViewLength))
+            make.leading.equalToSuperview().offset(horizontalPadding + (userRole == .admin ? 0 : dotViewLength + horizontalPadding))
             make.trailing.equalToSuperview().inset(numPercentSelectedTrailingPadding)
             make.height.equalTo(containerViewHeight)
             make.bottom.equalToSuperview()
         }
         
         optionLabel.snp.makeConstraints { make in
-
             make.leading.equalToSuperview().offset(horizontalPadding)
             make.trailing.lessThanOrEqualToSuperview().inset(horizontalPadding)
-//            make.trailing.equalToSuperview().inset(horizontalPadding)
             make.centerY.equalToSuperview()
             if showCorrectAnswer {
-                make.width.equalTo(optionLabelWidth >= maxWidth ? maxWidth : optionLabelWidth)
+                make.width.equalTo(optionLabelWidth >= maxLabelWidth ? maxLabelWidth : optionLabelWidth)
             } else {
-                make.width.equalTo(maxWidth)
+                make.width.equalTo(maxLabelWidth)
             }
         }
 

--- a/Pollo/Views/Cards/MCResultCell.swift
+++ b/Pollo/Views/Cards/MCResultCell.swift
@@ -101,7 +101,7 @@ class MCResultCell: UICollectionViewCell {
     override func updateConstraints() {
         guard let optionLabelText = optionLabel.text else { return }
         let optionLabelWidth = optionLabelText.width(withConstrainedHeight: bounds.height, font: optionLabel.font)
-        let maxWidth = bounds.width - horizontalPadding - numPercentSelectedTrailingPadding
+        let maxWidth = bounds.width - horizontalPadding - numPercentSelectedTrailingPadding - 2 * horizontalPadding
         
         // If we already laid out constraints before, we should only update the
         // highlightView width constraint
@@ -148,8 +148,10 @@ class MCResultCell: UICollectionViewCell {
         }
         
         optionLabel.snp.makeConstraints { make in
+
             make.leading.equalToSuperview().offset(horizontalPadding)
-            make.trailing.equalToSuperview().inset(horizontalPadding)
+            make.trailing.lessThanOrEqualToSuperview().inset(horizontalPadding)
+//            make.trailing.equalToSuperview().inset(horizontalPadding)
             make.centerY.equalToSuperview()
             if showCorrectAnswer {
                 make.width.equalTo(optionLabelWidth >= maxWidth ? maxWidth : optionLabelWidth)
@@ -165,7 +167,7 @@ class MCResultCell: UICollectionViewCell {
         
         numSelectedLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().inset(numSelectedLabelTopPadding)
-            make.leading.equalTo(containerView.snp.trailing).inset(horizontalPadding/3)
+            make.leading.equalTo(containerView.snp.trailing).offset(horizontalPadding/3)
             make.trailing.equalToSuperview().inset(horizontalPadding/3)
         }
         percentSelectedLabel.snp.makeConstraints { make in

--- a/Pollo/Views/Cards/PollOptionsCell.swift
+++ b/Pollo/Views/Cards/PollOptionsCell.swift
@@ -104,9 +104,6 @@ class PollOptionsCell: UICollectionViewCell, UIScrollViewDelegate {
             }
         }
 
-        optionGradientView.removeFromSuperview()
-        optionGradientView = OptionsGradientView(frame: frame)
-        contentView.addSubview(optionGradientView)
         optionGradientView.isHidden = !hasOverflowOptions
         optionGradientView.gradientLayer.endPoint = CGPoint(x: 0.5, y: delegate.userRole == .admin ? 0 : 0.25)
         optionGradientView.toggle(show: !optionGradientView.isHidden, animated: false)

--- a/Pollo/Views/Cards/PollOptionsCell.swift
+++ b/Pollo/Views/Cards/PollOptionsCell.swift
@@ -103,6 +103,10 @@ class PollOptionsCell: UICollectionViewCell, UIScrollViewDelegate {
                 mcSelectedIndex = selectedIndex
             }
         }
+
+        optionGradientView.removeFromSuperview()
+        optionGradientView = OptionsGradientView(frame: frame)
+        contentView.addSubview(optionGradientView)
         optionGradientView.isHidden = !hasOverflowOptions
         optionGradientView.gradientLayer.endPoint = CGPoint(x: 0.5, y: delegate.userRole == .admin ? 0 : 0.25)
         optionGradientView.toggle(show: !optionGradientView.isHidden, animated: false)

--- a/Pollo/Views/Cards/PollOptionsCell.swift
+++ b/Pollo/Views/Cards/PollOptionsCell.swift
@@ -93,7 +93,7 @@ class PollOptionsCell: UICollectionViewCell, UIScrollViewDelegate {
         self.correctAnswer = correctAnswer
         let currentCellHeight = calculatePollOptionsCellHeight(for: pollOptionsModel)
         switch pollOptionsModel.type {
-        case .mcResult(_):
+        case .mcResult:
             hasOverflowOptions = currentCellHeight > maxCellHeight
         case .mcChoice(let mcChoiceModels):
             hasOverflowOptions = currentCellHeight > maxCellHeight

--- a/Pollo/Views/OptionsGradientView.swift
+++ b/Pollo/Views/OptionsGradientView.swift
@@ -26,6 +26,11 @@ class OptionsGradientView: UIView {
         gradientLayer.startPoint = CGPoint(x: 0.5, y: 1)
         layer.addSublayer(gradientLayer)
     }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        gradientLayer.frame = frame
+    }
     
     func toggle(show: Bool, animated: Bool) {
         let opacity = CGFloat(show ? 1 : 0)


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->
Fixes OptionGradientView bug where it was ending before the bottom of the poll card


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
- Added `layoutSubviews` in OptionGradientView to update the gradient view's frame when the cell is reused and not initialized again
- Also modified optionLabel constraints in MCResultCell to get rid of autolayout errors in the console 


## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
Ran on simulator

## Related PRs or Issues

<!-- List related PRs against other branches/repositories. -->
Fixes #412 
Addresses some of #345 


## Screenshots
<!-- This could include of screenshots of the new feature / proof that the changes work. -->
See the last poll, and when you scroll back to the first long poll
<details>

  <summary>Original Bug</summary>


  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->
  
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/20599510/97098812-b5068000-1657-11eb-8ae7-20dcfb7ccdb0.gif)



</details>

<details>

  <summary>Fixed</summary>


  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->
  
![ezgif com-gif-maker](https://user-images.githubusercontent.com/20599510/97098786-6f49b780-1657-11eb-80f0-330ebab07db3.gif)



</details>
